### PR TITLE
feat: add a close button to the modal

### DIFF
--- a/src/components/ConnectionsSettingsModal.tsx
+++ b/src/components/ConnectionsSettingsModal.tsx
@@ -109,6 +109,7 @@ export const ConnectionsSettingsModal = (props: {
   onOrderChange: (value: ConnectionsTableColumnOrder) => void
   onVisibleChange: (value: ConnectionsTableColumnVisibility) => void
 }) => {
+  const modalID = MODAL.CONNECTIONS_SETTINGS
   const [t] = useI18n()
   const [activeKey, setActiveKey] =
     createSignal<CONNECTIONS_TABLE_ACCESSOR_KEY | null>(null)
@@ -175,14 +176,26 @@ export const ConnectionsSettingsModal = (props: {
   }
 
   return (
-    <dialog
-      id={MODAL.CONNECTIONS_SETTINGS}
-      class="modal modal-bottom sm:modal-middle"
-    >
+    <dialog id={modalID} class="modal modal-bottom sm:modal-middle">
       <div
         class="modal-box flex flex-col gap-4"
         onContextMenu={(e) => e.preventDefault()}
       >
+        <div class="sticky top-0 z-50 flex items-center justify-end">
+          <Button
+            class="btn-circle btn-sm text-xl"
+            onClick={() => {
+              const modal = document.querySelector(
+                `#${modalID}`,
+              ) as HTMLDialogElement | null
+
+              modal?.close()
+            }}
+          >
+            ✕
+          </Button>
+        </div>
+
         <div>
           <ConfigTitle withDivider>{t('tableSize')}</ConfigTitle>
 

--- a/src/components/ConnectionsTableDetailsModal.tsx
+++ b/src/components/ConnectionsTableDetailsModal.tsx
@@ -1,16 +1,31 @@
 import { Component, Show } from 'solid-js'
 import { MODAL } from '~/constants'
 import { allConnections } from '~/signals'
+import { Button } from './Button'
 
 export const ConnectionsTableDetailsModal: Component<{
   selectedConnectionID?: string
 }> = (props) => {
+  const modalID = MODAL.CONNECTIONS_TABLE_DETAILS
+
   return (
-    <dialog
-      id={MODAL.CONNECTIONS_TABLE_DETAILS}
-      class="modal modal-bottom sm:modal-middle"
-    >
+    <dialog id={modalID} class="modal modal-bottom sm:modal-middle">
       <div class="modal-box">
+        <div class="sticky top-0 z-50 flex items-center justify-end">
+          <Button
+            class="btn-circle btn-sm text-xl"
+            onClick={() => {
+              const modal = document.querySelector(
+                `#${modalID}`,
+              ) as HTMLDialogElement | null
+
+              modal?.close()
+            }}
+          >
+            ✕
+          </Button>
+        </div>
+
         <Show when={props.selectedConnectionID}>
           <pre>
             <code>

--- a/src/components/LogsSettingsModal.tsx
+++ b/src/components/LogsSettingsModal.tsx
@@ -1,9 +1,9 @@
 import { useI18n } from '@solid-primitives/i18n'
 import { For } from 'solid-js'
-import { ConfigTitle } from '~/components'
+import { Button, ConfigTitle } from '~/components'
 import {
-  LOG_LEVEL,
   LOGS_TABLE_MAX_ROWS_LIST,
+  LOG_LEVEL,
   MODAL,
   TAILWINDCSS_SIZE,
 } from '~/constants'
@@ -18,10 +18,26 @@ import {
 
 export const LogsSettingsModal = () => {
   const [t] = useI18n()
+  const modalID = MODAL.LOGS_SETTINGS
 
   return (
-    <dialog id={MODAL.LOGS_SETTINGS} class="modal modal-bottom sm:modal-middle">
+    <dialog id={modalID} class="modal modal-bottom sm:modal-middle">
       <div class="modal-box flex flex-col gap-4">
+        <div class="sticky top-0 z-50 flex items-center justify-end">
+          <Button
+            class="btn-circle btn-sm text-xl"
+            onClick={() => {
+              const modal = document.querySelector(
+                `#${modalID}`,
+              ) as HTMLDialogElement | null
+
+              modal?.close()
+            }}
+          >
+            ✕
+          </Button>
+        </div>
+
         <div>
           <ConfigTitle withDivider>{t('tableSize')}</ConfigTitle>
 

--- a/src/components/ProxiesSettingsModal.tsx
+++ b/src/components/ProxiesSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from '@solid-primitives/i18n'
 import { For } from 'solid-js'
-import { ConfigTitle } from '~/components'
+import { Button, ConfigTitle } from '~/components'
 import { MODAL, PROXIES_ORDERING_TYPE, PROXIES_PREVIEW_TYPE } from '~/constants'
 import {
   autoCloseConns,
@@ -18,14 +18,27 @@ import {
 } from '~/signals'
 
 export const ProxiesSettingsModal = () => {
+  const modalID = MODAL.PROXIES_SETTINGS
   const [t] = useI18n()
 
   return (
-    <dialog
-      id={MODAL.PROXIES_SETTINGS}
-      class="modal modal-bottom sm:modal-middle"
-    >
+    <dialog id={modalID} class="modal modal-bottom sm:modal-middle">
       <div class="modal-box flex flex-col gap-4">
+        <div class="sticky top-0 z-50 flex items-center justify-end">
+          <Button
+            class="btn-circle btn-sm text-xl"
+            onClick={() => {
+              const modal = document.querySelector(
+                `#${modalID}`,
+              ) as HTMLDialogElement | null
+
+              modal?.close()
+            }}
+          >
+            ✕
+          </Button>
+        </div>
+
         <div>
           <ConfigTitle withDivider>{t('autoCloseConns')}</ConfigTitle>
 


### PR DESCRIPTION
![image](https://github.com/MetaCubeX/metacubexd/assets/61853980/9f434ae1-4c52-47dd-bd05-be84a7b349e7)
给模态框右上角加个关闭按钮，顺便解决 iOS Safari 浏览器模态框占满屏不方便关闭的问题。
感觉可以给模态框封装个组件，毕竟有四个地方用到了。我现在对 solidjs 不太熟，说不定以后可以提个 pr。
