### PR TITLE
feat: proxy group is always placed at the forefront when sorting proxies

### DIFF
--- a/src/helpers/proxies.ts
+++ b/src/helpers/proxies.ts
@@ -38,12 +38,17 @@ export const sortProxiesByOrderingType = (
   proxyNames: string[],
   proxyLatencyMap: Record<string, number>,
   orderingType: PROXIES_ORDERING_TYPE,
+  proxyGroupNames: Set<string> | undefined,
 ) => {
   if (orderingType === PROXIES_ORDERING_TYPE.NATURAL) {
     return proxyNames
   }
 
   return proxyNames.sort((a, b) => {
+    if (proxyGroupNames?.has(a) && !proxyGroupNames?.has(b)) return -1
+
+    if (proxyGroupNames?.has(b) && !proxyGroupNames?.has(a)) return 1
+
     const prevLatency = proxyLatencyMap[a]
     const nextLatency = proxyLatencyMap[b]
 
@@ -77,10 +82,13 @@ export const sortProxiesByOrderingType = (
 export const filterProxiesByAvailability = (
   proxyNames: string[],
   proxyLatencyMap: Record<string, number>,
+  excludes: Set<string>,
   enabled?: boolean,
 ) =>
   enabled
-    ? proxyNames.filter(
-        (name) => proxyLatencyMap[name] !== latencyQualityMap().NOT_CONNECTED,
+    ? proxyNames.filter((name) =>
+        excludes?.has(name)
+          ? true
+          : proxyLatencyMap[name] !== latencyQualityMap().NOT_CONNECTED,
       )
     : proxyNames

--- a/src/pages/Proxies.tsx
+++ b/src/pages/Proxies.tsx
@@ -41,6 +41,7 @@ export default () => {
     proxies,
     selectProxyInGroup,
     latencyMap,
+    proxyGroupNames,
     proxyProviders,
     updateProviderByProviderName,
     updateAllProvider,
@@ -157,8 +158,10 @@ export default () => {
                       proxyGroup.all ?? [],
                       latencyMap(),
                       proxiesOrderingType(),
+                      proxyGroupNames(),
                     ),
                     latencyMap(),
+                    proxyGroupNames(),
                     hideUnAvailableProxies(),
                   ),
                 )
@@ -244,6 +247,7 @@ export default () => {
                     proxyProvider.proxies.map((i) => i.name) ?? [],
                     latencyMap(),
                     proxiesOrderingType(),
+                    undefined,
                   ),
                 )
 


### PR DESCRIPTION
+ proxy group is always placed at the forefront when sorting proxies
+ fix #322 
<img width="1263" alt="1701428658148" src="https://github.com/MetaCubeX/metacubexd/assets/8565764/9b99b1b4-8b8c-46e9-93c1-b08218c3d453">

+ recursively obtain the current latency of the proxy group