### PR TITLE
fix: failed IPv6 test overrides the default latency

### DIFF
--- a/src/signals/proxies.ts
+++ b/src/signals/proxies.ts
@@ -270,7 +270,10 @@ export const useProxies = () => {
     await proxyIPv6SupportTest(proxyName, provider)
   }
 
-  const proxyGroupLatencyTest = async (proxyGroupName: string) => {
+  const proxyGroupLatencyTest = async (
+    proxyGroupName: string,
+    disableTestIPv6?: boolean,
+  ) => {
     setProxyGroupLatencyTestingMap(proxyGroupName, async () => {
       const newLatencyMap = await proxyGroupLatencyTestAPI(
         proxyGroupName,
@@ -285,7 +288,15 @@ export const useProxies = () => {
 
       await fetchProxies()
     })
-    await proxyGroupIPv6SupportTest(proxyGroupName)
+
+    if (disableTestIPv6) return
+
+    try {
+      await proxyGroupIPv6SupportTest(proxyGroupName)
+    } catch {
+      // A failed IPv6 test will override the default latency, test again
+      await proxyGroupLatencyTest(proxyGroupName, true)
+    }
   }
 
   const updateProviderByProviderName = (providerName: string) =>


### PR DESCRIPTION
当不支持 ipv6 时，会覆盖默认的延迟时间，使其丢失，需要再执行一下默认的延迟测试，并禁用 IPv6 测试。