### PR TITLE
fix: compatible with clash.core and clash.premium

### DIFF
--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -252,7 +252,8 @@ const ConfigForm: Component<{ backendVersion: Accessor<string> }> = ({
               id="enable-tun-device"
               type="checkbox"
               class="toggle"
-              checked={configsData()?.tun.enable}
+              disabled={!configsData()?.tun}
+              checked={configsData()?.tun?.enable || false}
               onChange={(e) =>
                 void updateBackendConfigAPI(
                   'tun',
@@ -271,7 +272,7 @@ const ConfigForm: Component<{ backendVersion: Accessor<string> }> = ({
             <select
               id="tun-ip-stack"
               class="select select-bordered flex-1"
-              value={configsData()?.tun.stack}
+              value={configsData()?.tun?.stack || 'System'}
               onChange={(e) =>
                 void updateBackendConfigAPI(
                   'tun',
@@ -295,7 +296,7 @@ const ConfigForm: Component<{ backendVersion: Accessor<string> }> = ({
             <input
               id="device-name"
               class="input input-bordered min-w-0"
-              value={configsData()?.tun.device}
+              value={configsData()?.tun?.device || ''}
               onChange={(e) =>
                 void updateBackendConfigAPI(
                   'tun',


### PR DESCRIPTION
+ When using clash.core or clash.premium, it is impossible to switch the proxy mode because their API do not include tun-related options
<img width="1277" alt="image" src="https://github.com/MetaCubeX/metacubexd/assets/8565764/ecf1cebc-0b78-4bd8-aed9-96b7127ad90a">
