### PR TITLE
让 docker compose 配置支持匹配进程规则

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,14 @@ services:
     container_name: meta
     image: docker.io/metacubex/mihomo:Alpha
     restart: always
+    pid: host
+    ipc: host
     network_mode: host
     cap_add:
-      - NET_ADMIN
+      - ALL
     volumes:
       - ./config.yaml:/root/.config/mihomo
+      - /dev/net/tun:/dev/net/tun
 ```
 
 Running


### PR DESCRIPTION
Make the rule "PROCESS-NAME" work.