### PR TITLE
chore: auto configure from url param

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { usePrefersDark } from '@solid-primitives/media'
 import type { ParentComponent } from 'solid-js'
 import { twMerge } from 'tailwind-merge'
+import { v4 as uuid } from 'uuid'
 import { Header } from '~/components'
 import {
   WsMsg,
@@ -13,6 +14,9 @@ import {
   setLatestConnectionMsg,
   useTwemoji,
   useWsRequest,
+  //
+  setEndpointList,
+  setSelectedEndpoint,
 } from '~/signals'
 
 const ProtectedResources = () => {
@@ -25,6 +29,27 @@ const ProtectedResources = () => {
 
 export const App: ParentComponent = ({ children }) => {
   const prefersDark = usePrefersDark()
+
+  //
+  try {
+    const [searchParams, _] = useSearchParams();
+    const url = searchParams.url
+    if (url) {
+      const u = new URL(decodeURIComponent(url))
+      const apiSecret = u.username
+      u.username = ''
+      const apiURL = u.toString()
+
+      const id = uuid()
+      setEndpointList([{ id, url: apiURL, secret: apiSecret }])
+      setSelectedEndpoint(id)
+      const navigate = useNavigate()
+      navigate('/overview')
+
+      console.log('config from URL: url', apiURL, ', secret: ', apiSecret)
+    }
+  } catch(_) {}
+  //
 
   createEffect(() => {
     if (autoSwitchTheme())


### PR DESCRIPTION
佛系提交。。。

允许通过URL Param直接配置远程，方便被第三方应用调用

例子：
```
http://127.0.0.1:4173/#/setup?url={url(URLEncoded)}

url示例：
http://127.0.0.1:9090/ （无secret）
http://admin@127.0.0.1:9090/ （有secret）
```