### PR TITLE
fix: virtual scroll not working on rules page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,9 +41,7 @@ export const App: ParentComponent = ({ children }) => {
     >
       <Header />
 
-      <div class="flex-1 overflow-y-auto p-2 sm:p-4">
-        <div class="pb-8">{children}</div>
-      </div>
+      <div class="flex-1 overflow-y-auto p-2 sm:p-4">{children}</div>
 
       <Show when={endpoint()}>
         <ProtectedResources />


### PR DESCRIPTION
fix: #633, #573, #413

### Reason

外层的**pb-8**元素未设高度时，**scrollElement**滚动会失效，导致**virtual scroll**获取到错误的高度渲染了全部规则，引发页面卡顿。

![Snipaste_2024-07-09_14-58-43](https://github.com/MetaCubeX/metacubexd/assets/24680533/54ac04e7-33e3-4a09-acf4-3dc1ba796c20)

![Snipaste_2024-07-09_14-51-21](https://github.com/MetaCubeX/metacubexd/assets/24680533/e0d33187-0707-4e2b-897b-3d6745ff5c00)



### Preview

![preview](https://github.com/MetaCubeX/metacubexd/assets/24680533/7e5d0b7c-c726-4229-84fd-a23a0e215bc1)
