### PR TITLE
fix: location.search not work

### DIFF
--- a/src/pages/Setup.tsx
+++ b/src/pages/Setup.tsx
@@ -108,7 +108,7 @@ export default () => {
   }
 
   onMount(() => {
-    let search = location.search
+    let search = location.search || window.location.search
 
     if (search) {
       const searchList = location.hash.match(/\?.*$/)


### PR DESCRIPTION
原先的代码版本中像 `http://127.0.0.1/?hostname=1.2.3.4` 这样通过参数指定连接的地址不生效，只有 `http://127.0.0.1/#?hostname=1.2.3.4` 这么写才生效