### PR TITLE
fix: ipv6 latency test

### DIFF
--- a/src/signals/proxies.ts
+++ b/src/signals/proxies.ts
@@ -257,6 +257,7 @@ export const useProxies = () => {
   }
 
   const proxyLatencyTest = async (proxyName: string, provider: string) => {
+    await proxyIPv6SupportTest(proxyName, provider)
     setProxyLatencyTestingMap(proxyName, async () => {
       const { delay } = await proxyLatencyTestAPI(
         proxyName,
@@ -270,10 +271,10 @@ export const useProxies = () => {
         [proxyName]: delay,
       }))
     })
-    await proxyIPv6SupportTest(proxyName, provider)
   }
 
   const proxyGroupLatencyTest = async (proxyGroupName: string) => {
+    await proxyGroupIPv6SupportTest(proxyGroupName)
     setProxyGroupLatencyTestingMap(proxyGroupName, async () => {
       const newLatencyMap = await proxyGroupLatencyTestAPI(
         proxyGroupName,
@@ -288,7 +289,6 @@ export const useProxies = () => {
 
       await fetchProxies()
     })
-    await proxyGroupIPv6SupportTest(proxyGroupName)
   }
 
   const updateProviderByProviderName = (providerName: string) =>


### PR DESCRIPTION
The current solution triggers an IPv4 test first, followed by an IPv6 test. The IPv6 result will be the latest test result in the API history, I believe this is a misbehavior.