### PR TITLE
feat: quick filter for connections

### DIFF
--- a/src/components/ConnectionsSettingsModal.tsx
+++ b/src/components/ConnectionsSettingsModal.tsx
@@ -31,8 +31,10 @@ import {
   allConnections,
   clientSourceIPTags,
   connectionsTableSize,
+  quickFilterRegex,
   setClientSourceIPTags,
   setConnectionsTableSize,
+  setQuickFilterRegex,
 } from '~/signals'
 import {
   ConnectionsTableColumnOrder,
@@ -205,6 +207,16 @@ export const ConnectionsSettingsModal = (props: {
       }
     >
       <div class="flex flex-col gap-4">
+        <div>
+          <ConfigTitle withDivider>{t('quickFilter')}</ConfigTitle>
+          <input
+            type="text"
+            class="input input-bordered w-full"
+            onInput={(e) => setQuickFilterRegex(e.target.value)}
+            value={quickFilterRegex()}
+          ></input>
+        </div>
+
         <div>
           <ConfigTitle withDivider>{t('tableSize')}</ConfigTitle>
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -112,4 +112,5 @@ export default {
   en: 'English',
   zh: 'Chinese',
   port: '{{ name }} Port',
+  quickFilter: 'Quick Filter',
 }

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -114,4 +114,5 @@ export default {
   en: '英文',
   zh: '中文',
   port: '{{ name }} 端口',
+  quickFilter: '快速过滤',
 } satisfies Dict

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -244,7 +244,7 @@ const ConfigForm: Component<{ backendVersion: Accessor<string> }> = ({
               id="enable-tun-device"
               type="checkbox"
               class="toggle"
-              checked={configsData()?.tun.enable}
+              checked={configsData()?.tun?.enable}
               onChange={(e) =>
                 void updateBackendConfigAPI(
                   'tun',
@@ -263,7 +263,7 @@ const ConfigForm: Component<{ backendVersion: Accessor<string> }> = ({
             <select
               id="tun-ip-stack"
               class="select select-bordered flex-1"
-              value={configsData()?.tun.stack}
+              value={configsData()?.tun?.stack}
               onChange={(e) =>
                 void updateBackendConfigAPI(
                   'tun',
@@ -287,7 +287,7 @@ const ConfigForm: Component<{ backendVersion: Accessor<string> }> = ({
             <input
               id="device-name"
               class="input input-bordered min-w-0"
-              value={configsData()?.tun.device}
+              value={configsData()?.tun?.device}
               onChange={(e) =>
                 void updateBackendConfigAPI(
                   'tun',

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -87,8 +87,8 @@ export default () => {
   ])
 
   return (
-    <div class="flex flex-col gap-2">
-      <div class="stats stats-vertical w-full grid-cols-2 bg-primary shadow lg:stats-horizontal lg:flex">
+    <div class="flex flex-col gap-2 lg:h-full">
+      <div class="stats stats-vertical w-full flex-shrink-0 grid-cols-2 bg-gradient-to-br from-primary to-secondary shadow lg:stats-horizontal lg:flex">
         <TrafficWidget label={t('upload')}>
           {byteSize(traffic()?.up || 0).toString()}/s
         </TrafficWidget>

--- a/src/pages/Proxies.tsx
+++ b/src/pages/Proxies.tsx
@@ -1,3 +1,4 @@
+import { makePersisted } from '@solid-primitives/storage'
 import {
   IconBrandSpeedtest,
   IconReload,
@@ -55,13 +56,23 @@ export default () => {
     updateAllProvider,
     proxyGroupLatencyTest,
     proxyProviderLatencyTest,
-    collapsedMap,
-    setCollapsedMap,
     proxyGroupLatencyTestingMap,
     proxyProviderLatencyTestingMap,
     isAllProviderUpdating,
     updatingMap,
   } = useProxies()
+
+  const [collapsedMap, setCollapsedMap] = makePersisted(
+    createSignal<Record<string, boolean>>({}),
+    {
+      name: 'collapsedMap',
+      storage: localStorage,
+    },
+  )
+
+  const setCollapsedMapByKey = (key: string, value: boolean) => {
+    setCollapsedMap((prev) => ({ ...prev, [key]: value }))
+  }
 
   onMount(fetchProxies)
 
@@ -221,7 +232,9 @@ export default () => {
                   <Collapse
                     isOpen={collapsedMap()[proxyGroup.name]}
                     title={title}
-                    onCollapse={(val) => setCollapsedMap(proxyGroup.name, val)}
+                    onCollapse={(val) =>
+                      setCollapsedMapByKey(proxyGroup.name, val)
+                    }
                   >
                     <For each={sortedProxyNames()}>
                       {(proxyName) => (
@@ -330,7 +343,7 @@ export default () => {
                     isOpen={collapsedMap()[proxyProvider.name]}
                     title={title}
                     onCollapse={(val) =>
-                      setCollapsedMap(proxyProvider.name, val)
+                      setCollapsedMapByKey(proxyProvider.name, val)
                     }
                   >
                     <For each={sortedProxyNames()}>

--- a/src/signals/connections.ts
+++ b/src/signals/connections.ts
@@ -1,3 +1,4 @@
+import { makePersisted } from '@solid-primitives/storage'
 import { differenceWith, isNumber, unionWith } from 'lodash'
 import { CONNECTIONS_TABLE_MAX_CLOSED_ROWS } from '~/constants'
 import { Connection, ConnectionRawMessage } from '~/types'
@@ -7,6 +8,14 @@ export type WsMsg = {
   uploadTotal: number
   downloadTotal: number
 } | null
+
+export const [quickFilterRegex, setQuickFilterRegex] = makePersisted(
+  createSignal<string>('Direct|direct|dns-out'),
+  {
+    name: 'quickFilterRegex',
+    storage: localStorage,
+  },
+)
 
 // we make connections global, so we can keep track of connections when user in proxy page
 // when user selects proxy and close some connections they can back and check connections

--- a/src/signals/proxies.ts
+++ b/src/signals/proxies.ts
@@ -32,7 +32,6 @@ type ProxyInfo = {
 export type ProxyWithProvider = Proxy & { provider?: string }
 export type ProxyNodeWithProvider = ProxyNode & { provider?: string }
 
-const { map: collapsedMap, set: setCollapsedMap } = useStringBooleanMap()
 const {
   map: proxyLatencyTestingMap,
   setWithCallback: setProxyLatencyTestingMap,
@@ -322,8 +321,6 @@ export const useProxies = () => {
     })
 
   return {
-    collapsedMap,
-    setCollapsedMap,
     proxyIPv6SupportMap,
     proxyLatencyTestingMap,
     proxyGroupLatencyTestingMap,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e8f3e213-cf8b-486b-bd93-3948a9d964fa)
![image](https://github.com/user-attachments/assets/6a631c6e-eb3d-48cd-bfd6-578173d10d4d)
A quick filter option that filters connections's chain using regex, allowing router users to quickly filter out unwanted direct connection or dns-out connection for sing-box users with one click, the regex can be customize