### PR TITLE
fix: latency test for selector and ipv6 test

### DIFF
--- a/src/components/IPv6Support.tsx
+++ b/src/components/IPv6Support.tsx
@@ -1,14 +1,16 @@
 import { useProxies } from '~/signals'
+import { proxyIPv6SupportMap } from '~/signals/ipv6'
 
-export const IPv6Support = (props: { name?: string }) => {
-  const { proxyIPv6SupportMap } = useProxies()
-  const support = createMemo(() => proxyIPv6SupportMap()[props.name!] === true)
+export const IPv6Support = (props: { name?: string; class?: string }) => {
+  const { getNowProxyNodeName } = useProxies()
+
+  const support = createMemo(() => {
+    return proxyIPv6SupportMap()[getNowProxyNodeName(props.name || '')]
+  })
 
   return (
     <Show when={support()}>
-      <span class="badge badge-sm p-px">
-        <span class="scale-75">IPv6</span>
-      </span>
+      <span class={`scale-75 ${props.class}`}>IPv6</span>
     </Show>
   )
 }

--- a/src/components/Latency.tsx
+++ b/src/components/Latency.tsx
@@ -4,9 +4,11 @@ import { latencyQualityMap, useProxies } from '~/signals'
 
 export const Latency = (props: { name?: string; class?: string }) => {
   const [t] = useI18n()
-  const { latencyMap } = useProxies()
+  const { getNowProxyNodeName, latencyMap } = useProxies()
   const [textClassName, setTextClassName] = createSignal('')
-  const latency = createMemo(() => latencyMap()[props.name!])
+  const latency = createMemo(() => {
+    return latencyMap()[getNowProxyNodeName(props.name || '')]
+  })
 
   createEffect(() => {
     setTextClassName('text-success')

--- a/src/signals/connections.ts
+++ b/src/signals/connections.ts
@@ -9,8 +9,10 @@ export type WsMsg = {
   downloadTotal: number
 } | null
 
+// DIRECT is from clash
+// direct and dns-out is from the example of sing-box official site
 export const [quickFilterRegex, setQuickFilterRegex] = makePersisted(
-  createSignal<string>('Direct|direct|dns-out'),
+  createSignal<string>('DIRECT|direct|dns-out'),
   {
     name: 'quickFilterRegex',
     storage: localStorage,

--- a/src/signals/ipv6.ts
+++ b/src/signals/ipv6.ts
@@ -1,0 +1,66 @@
+import { proxyGroupLatencyTestAPI, proxyLatencyTestAPI } from '~/apis'
+import {
+  latencyQualityMap,
+  latencyTestTimeoutDuration,
+  urlForIPv6SupportTest,
+} from './config'
+
+export const [proxyIPv6SupportMap, setProxyIPv6SupportMap] = createSignal<
+  Record<string, boolean>
+>({})
+
+export const proxyIPv6SupportTest = async (
+  proxyName: string,
+  provider: string,
+) => {
+  const urlForTest = urlForIPv6SupportTest()
+
+  if (!urlForTest || urlForTest.length === 0) {
+    setProxyIPv6SupportMap({})
+
+    return
+  }
+
+  let support = false
+  try {
+    const { delay } = await proxyLatencyTestAPI(
+      proxyName,
+      provider,
+      urlForTest,
+      latencyTestTimeoutDuration(),
+    )
+    support = delay > latencyQualityMap().NOT_CONNECTED
+  } catch {
+    support = false
+  }
+  setProxyIPv6SupportMap((supportMap) => ({
+    ...supportMap,
+    [proxyName]: support,
+  }))
+}
+
+export const proxyGroupIPv6SupportTest = async (proxyGroupName: string) => {
+  const urlForTest = urlForIPv6SupportTest()
+
+  if (!urlForTest || urlForTest.length === 0) {
+    setProxyIPv6SupportMap({})
+
+    return
+  }
+
+  const newLatencyMap = await proxyGroupLatencyTestAPI(
+    proxyGroupName,
+    urlForTest,
+    latencyTestTimeoutDuration(),
+  )
+  const newSupportMap = Object.fromEntries(
+    Object.entries(newLatencyMap).map(([k, v]) => [
+      k,
+      v > latencyQualityMap().NOT_CONNECTED,
+    ]),
+  )
+  setProxyIPv6SupportMap((supportMap) => ({
+    ...supportMap,
+    ...newSupportMap,
+  }))
+}


### PR DESCRIPTION
Remove useless logic for latency, for the seletor and urltest group we simply use it as a pointer to point the real latency for render
For ipv6 test, this part of code is a nightmare, i try my best, already tested on sing-box for single node latency test and proxy groups latency test, but not provider latencty test since i don't have one