### PR TITLE
fix: latency not correct when set custom url in config

### DIFF
--- a/src/components/Latency.tsx
+++ b/src/components/Latency.tsx
@@ -1,17 +1,23 @@
 import { JSX, ParentComponent } from 'solid-js'
 import { twMerge } from 'tailwind-merge'
 import { getLatencyClassName } from '~/helpers'
-import { useProxies } from '~/signals'
+import { urlForLatencyTest, useProxies } from '~/signals'
 
 interface Props extends JSX.HTMLAttributes<HTMLSpanElement> {
   proxyName: string
+  testUrl: string | null
 }
 
 export const Latency: ParentComponent<Props> = (props) => {
   const [local, others] = splitProps(props, ['class'])
   const { getLatencyByName } = useProxies()
   const [textClassName, setTextClassName] = createSignal('')
-  const latency = createMemo(() => getLatencyByName(others.proxyName || ''))
+  const latency = createMemo(() =>
+    getLatencyByName(
+      others.proxyName || '',
+      others.testUrl || urlForLatencyTest(),
+    ),
+  )
 
   createEffect(() => {
     setTextClassName(getLatencyClassName(latency()))
@@ -19,7 +25,11 @@ export const Latency: ParentComponent<Props> = (props) => {
 
   return (
     <span
-      class={twMerge('badge w-11 whitespace-nowrap', textClassName(), local.class)}
+      class={twMerge(
+        'badge w-11 whitespace-nowrap',
+        textClassName(),
+        local.class,
+      )}
       {...others}
     >
       {latency() || '---'}

--- a/src/components/ProxyNodePreview.tsx
+++ b/src/components/ProxyNodePreview.tsx
@@ -4,6 +4,7 @@ import { proxiesPreviewType } from '~/signals'
 
 export const ProxyNodePreview = (props: {
   proxyNameList: string[]
+  testUrl: string | null
   now?: string
 }) => {
   const off = () => proxiesPreviewType() === PROXIES_PREVIEW_TYPE.OFF
@@ -34,6 +35,7 @@ export const ProxyNodePreview = (props: {
         <Match when={isShowBar()}>
           <ProxyPreviewBar
             proxyNameList={props.proxyNameList}
+            testUrl={props.testUrl}
             now={props.now}
           />
         </Match>
@@ -41,6 +43,7 @@ export const ProxyNodePreview = (props: {
         <Match when={isShowDots()}>
           <ProxyPreviewDots
             proxyNameList={props.proxyNameList}
+            testUrl={props.testUrl}
             now={props.now}
           />
         </Match>

--- a/src/components/ProxyPreviewBar.tsx
+++ b/src/components/ProxyPreviewBar.tsx
@@ -3,11 +3,12 @@ import { latencyQualityMap, useProxies } from '~/signals'
 
 export const ProxyPreviewBar = (props: {
   proxyNameList: string[]
+  testUrl: string | null
   now?: string
 }) => {
   const { getLatencyByName } = useProxies()
   const latencyList = createMemo(() =>
-    props.proxyNameList.map((name) => getLatencyByName(name)),
+    props.proxyNameList.map((name) => getLatencyByName(name, props.testUrl)),
   )
 
   const all = createMemo(() => latencyList().length)
@@ -69,7 +70,7 @@ export const ProxyPreviewBar = (props: {
       </div>
 
       <Show when={props.now}>
-        <Latency proxyName={props.now!} />
+        <Latency proxyName={props.now!} testUrl={props.testUrl} />
       </Show>
     </div>
   )

--- a/src/components/ProxyPreviewDots.tsx
+++ b/src/components/ProxyPreviewDots.tsx
@@ -38,6 +38,7 @@ const LatencyDot = (props: {
 
 export const ProxyPreviewDots = (props: {
   proxyNameList: string[]
+  testUrl: string | null
   now?: string
 }) => {
   const { getLatencyByName } = useProxies()
@@ -48,7 +49,7 @@ export const ProxyPreviewDots = (props: {
         <For
           each={props.proxyNameList.map((name): [string, number] => [
             name,
-            getLatencyByName(name),
+            getLatencyByName(name, props.testUrl),
           ])}
         >
           {([name, latency]) => (
@@ -62,7 +63,7 @@ export const ProxyPreviewDots = (props: {
       </div>
 
       <Show when={props.now}>
-        <Latency proxyName={props.now!} />
+        <Latency proxyName={props.now!} testUrl={props.testUrl} />
       </Show>
     </div>
   )

--- a/src/pages/Proxies.tsx
+++ b/src/pages/Proxies.tsx
@@ -198,13 +198,15 @@ export default () => {
               <For each={renderProxies()}>
                 {(proxyGroup) => {
                   const sortedProxyNames = createMemo(() =>
-                    filterProxiesByAvailability(
-                      sortProxiesByOrderingType(
-                        proxyGroup.all ?? [],
-                        proxiesOrderingType(),
-                      ),
-                      hideUnAvailableProxies(),
-                    ),
+                    filterProxiesByAvailability({
+                      proxyNames: sortProxiesByOrderingType({
+                        proxyNames: proxyGroup.all ?? [],
+                        orderingType: proxiesOrderingType(),
+                        testUrl: proxyGroup.testUrl || null,
+                      }),
+                      enabled: hideUnAvailableProxies(),
+                      testUrl: proxyGroup.testUrl || null,
+                    }),
                   )
 
                   const title = (
@@ -291,6 +293,7 @@ export default () => {
                         <ProxyNodePreview
                           proxyNameList={sortedProxyNames()}
                           now={proxyGroup.now}
+                          testUrl={proxyGroup.testUrl || null}
                         />
                       </Show>
                     </div>
@@ -308,6 +311,8 @@ export default () => {
                         {(proxyName) => (
                           <ProxyNodeCard
                             proxyName={proxyName}
+                            testUrl={proxyGroup.testUrl || null}
+                            timeout={proxyGroup.timeout ?? null}
                             isSelected={proxyGroup.now === proxyName}
                             onClick={() =>
                               void selectProxyInGroup(proxyGroup, proxyName)
@@ -327,10 +332,12 @@ export default () => {
               <For each={proxyProviders()}>
                 {(proxyProvider) => {
                   const sortedProxyNames = createMemo(() =>
-                    sortProxiesByOrderingType(
-                      proxyProvider.proxies.map((i) => i.name) ?? [],
-                      proxiesOrderingType(),
-                    ),
+                    sortProxiesByOrderingType({
+                      orderingType: proxiesOrderingType(),
+                      proxyNames:
+                        proxyProvider.proxies.map((i) => i.name) ?? [],
+                      testUrl: proxyProvider.testUrl,
+                    }),
                   )
 
                   const title = (
@@ -397,7 +404,10 @@ export default () => {
                       </div>
 
                       <Show when={!collapsedMap()[proxyProvider.name]}>
-                        <ProxyNodePreview proxyNameList={sortedProxyNames()} />
+                        <ProxyNodePreview
+                          proxyNameList={sortedProxyNames()}
+                          testUrl={proxyProvider.testUrl}
+                        />
                       </Show>
                     </>
                   )
@@ -411,7 +421,13 @@ export default () => {
                       }
                     >
                       <For each={sortedProxyNames()}>
-                        {(proxyName) => <ProxyNodeCard proxyName={proxyName} />}
+                        {(proxyName) => (
+                          <ProxyNodeCard
+                            proxyName={proxyName}
+                            testUrl={proxyProvider.testUrl}
+                            timeout={proxyProvider.timeout ?? null}
+                          />
+                        )}
                       </For>
                     </Collapse>
                   )

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -23,6 +23,8 @@ export type Proxy = {
   xudp: boolean
   tfo: boolean
   now: string
+  testUrl?: string
+  timeout?: number
 }
 
 export type ProxyNode = {
@@ -53,6 +55,7 @@ export type ProxyProvider = {
   name: string
   proxies: ProxyNode[]
   testUrl: string
+  timeout?: number
   updatedAt: string
   vehicleType: string
 }


### PR DESCRIPTION
Currently, there are two main issues with latency testing:

1. When there is a custom testUrl in the configuration file, clicking the speed test does not use the URL from the config file, but instead uses the global configuration
2. The current implementation logic is not strongly bound to testUrl. When fixing the first issue, it causes all identical proxy nodes across different proxy groups to have the same latency time, and their corresponding historical speed test results are also incorrect. This behavior is not as expected

To thoroughly fix this issue, all latency-related logic needs to be strongly bound to testurl

---

Example Config:

```yaml
  - name: SteamDirect
    type: select
    proxies:
      - DIRECT
      - Proxy
  - name: Home
    type: select
    proxies:
      - DIRECT
      - xray-home
    url: http://wifi.vivo.com.cn/generate_204
```

before fix:

![image](https://github.com/user-attachments/assets/81bba7ed-7198-4218-86f3-cc7c70057b55)

after fix:

![image](https://github.com/user-attachments/assets/2cf22101-c8c0-493e-9c72-d201acf980c0)
