### PR TITLE
fix: Fall back to the original value in non-presupposition routing modes under i18n

### DIFF
--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -269,7 +269,7 @@ const ConfigForm: ParentComponent<{
             <For each={modes()}>
               {(name) => (
                 <option selected={name === configsData()?.mode} value={name}>
-                  {t(name as keyof Dict)}
+                  {t(name as keyof Dict) ?? name}
                 </option>
               )}
             </For>


### PR DESCRIPTION
![Screenshot_2024-11-30-23-20-29-819_mark via](https://github.com/user-attachments/assets/3459b262-ec79-42e7-ab25-14bf17ef58ef)
