### PR TITLE
feat: set default DNS query target same as the placeholder

### DIFF
--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -91,6 +91,7 @@ const dnsQueryFormSchema = z.object({
 const DNSQueryForm = () => {
   const [t] = useI18n()
   const request = useRequest()
+  const defaultDNSQueryTarget = 'google.com'
 
   const { form, isSubmitting } = createForm<z.infer<typeof dnsQueryFormSchema>>(
     {
@@ -98,7 +99,10 @@ const DNSQueryForm = () => {
       onSubmit: (values) =>
         request
           .get('dns/query', {
-            searchParams: { name: values.name, type: values.type },
+            searchParams: {
+              name: values.name || defaultDNSQueryTarget,
+              type: values.type,
+            },
           })
           .json<DNSQuery>()
           .then(({ Answer }) =>
@@ -117,7 +121,7 @@ const DNSQueryForm = () => {
           type="search"
           name="name"
           class="flex-1"
-          placeholder="google.com"
+          placeholder={defaultDNSQueryTarget}
           onInput={(e) => {
             if (!e.target.value) setDNSQueryResult([])
           }}


### PR DESCRIPTION
<img width="786" alt="image" src="https://github.com/user-attachments/assets/f367717a-aaff-464d-afd0-7a6cfb61e660" />


这个PR旨在提升用户体验，如果这里什么也不填写就点击查询，那么默认就应该查询 `google.com`并给出结果，而不是静默查询空字符串然后什么也不提示。