### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -21,6 +26,9 @@ jobs:
           release-type: node
 
   release-assets:
+    permissions:
+      contents: read
+      packages: write
     needs: release-please
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}
@@ -59,6 +67,9 @@ jobs:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
 
   release-image:
+    permissions:
+      contents: read
+      packages: write
     needs: release-please
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
Potential fix for [https://github.com/MetaCubeX/metacubexd/security/code-scanning/3](https://github.com/MetaCubeX/metacubexd/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks for jobs that require elevated permissions. For example:
- The `release-please` job requires `contents: write` to create releases.
- The `release-assets` job requires `contents: read` and `packages: write` to publish assets.
- The `release-image` job requires `contents: read` and `packages: write` to build and push Docker images.

This ensures that each job has only the permissions it needs, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
