### PR TITLE
fix: Twemoji does not work on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,7 @@
     @apply rounded-box bg-primary;
   }
 }
+
+option {
+  font-family: system-ui;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,8 @@
 }
 
 @theme {
-  --font-fira-sans: FiraSans, system-ui, 'Twemoji Mozilla', monospace;
-  --font-system-ui: system-ui, 'Twemoji Mozilla', monospace;
+  --font-fira-sans: FiraSans, 'Twemoji Mozilla', system-ui, monospace;
+  --font-system-ui: 'Twemoji Mozilla', system-ui, monospace;
 }
 
 @font-face {


### PR DESCRIPTION
提高Twemoji Mozilla的优先级使其可以在ios上显示
firefox的选择框字体有些问题，Twemoji在前会无法显示数字，所以直接把option标签的字体固定为system-ui

fix #1045