### PR TITLE
feat: verify API endpoint with `/version` (#1568)

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -13,7 +13,7 @@ import {
 
 export const checkEndpointAPI = (url: string, secret: string) =>
   ky
-    .get(url, {
+    .get(url.endsWith('/') ? `${url}version` : `${url}/version`, {
       headers: secret
         ? {
             Authorization: `Bearer ${secret}`,


### PR DESCRIPTION
As analyzed in the #1568 , the verification API endpoint has changed from `/` to `/version` .