### PR TITLE
feat(ui): replace mobile sidenav with bottom navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,17 +2,35 @@ import {
   IconFileStack,
   IconGlobe,
   IconHome,
-  IconMenu,
   IconNetwork,
   IconPalette,
   IconRuler,
   IconSettings,
 } from '@tabler/icons-solidjs'
-import type { ParentComponent } from 'solid-js'
+import type { JSX, ParentComponent } from 'solid-js'
 import { LogoText } from '~/components'
 import { ROUTES, themes } from '~/constants'
 import { useI18n } from '~/i18n'
 import { setCurTheme } from '~/signals'
+
+interface NavItem {
+  href: string
+  name: string
+  icon: JSX.Element
+}
+
+const useNavItems = () => {
+  const [t] = useI18n()
+
+  return [
+    { href: ROUTES.Overview, name: t('overview'), icon: <IconHome /> },
+    { href: ROUTES.Proxies, name: t('proxies'), icon: <IconGlobe /> },
+    { href: ROUTES.Rules, name: t('rules'), icon: <IconRuler /> },
+    { href: ROUTES.Conns, name: t('connections'), icon: <IconNetwork /> },
+    { href: ROUTES.Log, name: t('logs'), icon: <IconFileStack /> },
+    { href: ROUTES.Config, name: t('config'), icon: <IconSettings /> },
+  ] as NavItem[]
+}
 
 const Nav: ParentComponent<{ href: string; tooltip: string }> = ({
   href,
@@ -59,102 +77,90 @@ const ThemeSwitcher = () => (
   </div>
 )
 
-export const Header = () => {
-  const [t] = useI18n()
-  const navs = () => [
-    {
-      href: ROUTES.Overview,
-      name: t('overview'),
-      icon: <IconHome />,
-    },
-    {
-      href: ROUTES.Proxies,
-      name: t('proxies'),
-      icon: <IconGlobe />,
-    },
-    {
-      href: ROUTES.Rules,
-      name: t('rules'),
-      icon: <IconRuler />,
-    },
-    {
-      href: ROUTES.Conns,
-      name: t('connections'),
-      icon: <IconNetwork />,
-    },
-    {
-      href: ROUTES.Log,
-      name: t('logs'),
-      icon: <IconFileStack />,
-    },
-    {
-      href: ROUTES.Config,
-      name: t('config'),
-      icon: <IconSettings />,
-    },
-  ]
-
+const MobileBottomNav = () => {
+  const navs = useNavItems()
   const location = useLocation()
 
-  const [openedDrawer, setOpenedDrawer] = createSignal(false)
+  createEffect(() => {
+    const shouldShow = location.pathname !== ROUTES.Setup
+    document.body.style.paddingBottom =
+      shouldShow && window.innerWidth < 1024 ? '4rem' : '0'
+  })
+
+  onCleanup(() => {
+    document.body.style.paddingBottom = '0'
+  })
 
   return (
-    <ul class="z-50 navbar flex w-auto items-center justify-center bg-base-300 px-4 shadow-lg">
-      <div class="navbar-start gap-4">
-        <div class="drawer w-auto lg:hidden">
-          <input
-            id="navs"
-            type="checkbox"
-            class="drawer-toggle"
-            onChange={(e) => setOpenedDrawer(e.target.checked)}
-            checked={openedDrawer()}
-          />
+    <Show when={location.pathname !== ROUTES.Setup}>
+      <nav class="fixed inset-x-0 bottom-0 z-50 border-t border-base-content/10 bg-base-300/95 backdrop-blur-sm lg:hidden">
+        <div class="grid h-16 grid-cols-6">
+          <For each={navs}>
+            {({ href, name, icon }) => {
+              const isActive = () => location.pathname === href
 
-          <div class="drawer-content flex w-6 items-center">
-            <label for="navs" class="drawer-button btn btn-circle btn-sm">
-              <IconMenu />
-            </label>
-          </div>
+              return (
+                <A
+                  href={href}
+                  class="relative flex flex-col items-center justify-center gap-1 transition-all duration-200 hover:bg-base-200/50"
+                >
+                  <Show when={isActive()}>
+                    <div class="absolute top-0 left-1/2 h-1 w-8 -translate-x-1/2 transform rounded-b-full bg-primary" />
+                  </Show>
+                  <div
+                    class="text-xl transition-all duration-200"
+                    classList={{
+                      'text-primary scale-110': isActive(),
+                      'text-base-content/70': !isActive(),
+                    }}
+                  >
+                    {icon}
+                  </div>
+                  <Show when={isActive()}>
+                    <span class="animate-in fade-in slide-in-from-bottom-1 text-xs font-medium text-primary duration-200">
+                      {name}
+                    </span>
+                  </Show>
+                </A>
+              )
+            }}
+          </For>
+        </div>
+      </nav>
+    </Show>
+  )
+}
 
-          <div class="drawer-side">
-            <label for="navs" class="drawer-overlay" />
+export const Header = () => {
+  const navs = useNavItems()
+  const location = useLocation()
 
-            <ul class="menu min-h-full min-w-2/5 gap-2 rounded-r-box bg-base-300 pt-20">
-              <For each={navs()}>
+  return (
+    <>
+      <header class="z-50 navbar flex w-auto items-center justify-center bg-base-300 px-4 shadow-lg">
+        <div class="navbar-start">
+          <LogoText />
+        </div>
+
+        <Show when={location.pathname !== ROUTES.Setup}>
+          <nav class="navbar-center hidden lg:flex">
+            <ul class="menu menu-horizontal gap-2 menu-lg p-0">
+              <For each={navs}>
                 {({ href, name, icon }) => (
-                  <li onClick={() => setOpenedDrawer(false)}>
-                    <A href={href} activeClass="menu-active">
-                      {icon} {name}
-                    </A>
-                  </li>
+                  <Nav href={href} tooltip={name}>
+                    {icon}
+                  </Nav>
                 )}
               </For>
             </ul>
-          </div>
-        </div>
+          </nav>
+        </Show>
 
-        <LogoText />
-      </div>
-
-      <Show when={location.pathname !== ROUTES.Setup}>
-        <div class="navbar-center hidden lg:flex">
-          <ul class="menu menu-horizontal gap-2 menu-lg p-0">
-            <For each={navs()}>
-              {({ href, name, icon }) => (
-                <Nav href={href} tooltip={name}>
-                  {icon}
-                </Nav>
-              )}
-            </For>
-          </ul>
-        </div>
-      </Show>
-
-      <div class="navbar-end">
-        <div class="flex items-center gap-2">
+        <div class="navbar-end">
           <ThemeSwitcher />
         </div>
-      </div>
-    </ul>
+      </header>
+      <MobileBottomNav />
+    </>
   )
 }


### PR DESCRIPTION
## 📝 Description
Hello maintainers 👋,  

This PR updates the **mobile navigation** by replacing the old sidenav (hamburger drawer) with a **bottom navigation bar**.

---

## ✨ Motivation
- Improve **UX on mobile devices** by making navigation easier to reach with the thumb.  
- Provide a more **modern and consistent look**, aligned with common mobile app design patterns.  
- Eliminate the extra step of opening/closing a drawer to switch between pages.  

---

## 🔧 Changes
- Removed the mobile sidenav and `IconMenu`.  
- Added a new `MobileBottomNav` component for bottom navigation.  
- Applied automatic bottom padding on `<body>` when the bottom nav is active (to prevent content overlap).  
- Refactored `Header`:  
  - Extracted `useNavItems()` helper to avoid duplicate nav definitions.  
  - Split into smaller components (`Nav`, `ThemeSwitcher`, `MobileBottomNav`) for better readability and maintainability.  
- No changes to the **desktop navigation** (remains the same top navbar).  

---

## 📱 Before / After (Mobile)
**Before (Sidenav):**  
<img width="497" height="896" alt="before" src="https://github.com/user-attachments/assets/36b5f5bc-da41-421b-970c-84c95cffc612" />

**After (Bottom Nav):**  
<img width="497" height="896" alt="after" src="https://github.com/user-attachments/assets/9f63e02a-f683-42bd-bcd0-48bba887a58f" />

---

## ✅ Checklist
- [x] Bottom navigation shows only on mobile (`lg:hidden`).  
- [x] Desktop navigation remains unchanged.  
- [x] Tested on Chrome DevTools responsive mode.  
- [x] Theme switcher still works properly.  
