### PR TITLE
feat: support linux/arm64 docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |


### PR DESCRIPTION
## Summary

Add `linux/arm64` platform support to Docker image builds, enabling ARM64 devices (Raspberry Pi, Apple Silicon Linux VMs, AWS Graviton, etc.) to pull and run the image natively.

Closes #1815

## Changes

- Added `linux/arm64` to the `platforms` field in the Docker build step of `release.yml`

## Notes

- The existing `docker/setup-qemu-action` and `docker/setup-buildx-action` already support multi-platform builds — only the `platforms` field was missing `arm64`
- The `node:alpine` base image in the Dockerfile natively supports `arm64`, so no Dockerfile changes are needed
- Locally tested both `linux/amd64` and `linux/arm64` builds successfully