### PR TITLE
fix: move proxy group filter from speedGroupByName to overview page (#1847)

### DIFF
--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -21,8 +21,16 @@ const globalStore = useGlobalStore()
 const connectionsStore = useConnectionsStore()
 const endpointStore = useEndpointStore()
 const configStore = useConfigStore()
+const proxiesStore = useProxiesStore()
 
 const formatBytes = (bytes: number) => byteSize(bytes).toString()
+
+// Ensure proxy data is available for isProxyGroup filtering in top proxies chart
+onMounted(() => {
+  if (proxiesStore.proxies.length === 0) {
+    proxiesStore.fetchProxies()
+  }
+})
 
 // Reactive theme colors - recomputes when theme changes
 const themeColors = computed(() => {
@@ -230,8 +238,9 @@ const networkTypesChartOptions = computed<Highcharts.Options>(() => {
 const topProxiesChartOptions = computed<Highcharts.Options>(() => {
   const speedByName = connectionsStore.speedGroupByName
 
-  // Get top 5 proxies by speed
+  // Get top 5 proxies by speed, excluding proxy groups
   const sortedProxies = Object.entries(speedByName)
+    .filter(([name]) => !proxiesStore.isProxyGroup(name))
     .sort(([, a], [, b]) => b - a)
     .slice(0, 5)
 

--- a/stores/connections.ts
+++ b/stores/connections.ts
@@ -306,15 +306,12 @@ export const useConnectionsStore = defineStore('connections', () => {
     dataUsageMap.value = updates
   }
 
-  // Computed: speed grouped by proxy name (excluding proxy groups)
+  // Computed: speed grouped by proxy name
   const speedGroupByName = computed(() => {
-    const proxiesStore = useProxiesStore()
     const returnMap: Record<string, number> = {}
 
     activeConnections.value.forEach((c) => {
       c.chains.forEach((chain) => {
-        if (proxiesStore.isProxyGroup(chain)) return
-
         if (!returnMap[chain]) {
           returnMap[chain] = 0
         }


### PR DESCRIPTION
## Summary

Fixes a regression from #1847 where the proxy group filtering in `speedGroupByName` broke speed display on the proxies page.

## Problem

The `isProxyGroup` filter was added inside `speedGroupByName` (connections store) to exclude proxy groups from the overview "Top Proxies" chart. This caused
two issues:

1. **Proxies page broken**: `proxies.vue` looks up speed by proxy group name (`speedGroupByName[proxyGroup.name]`). Since groups were filtered out at the
source, the lookup always returned `undefined`, showing `0/s` for all groups.
2. **Overview page edge case**: If `/overview` is opened first (before visiting `/proxies`), the proxies store has no data yet — `proxyNodeMap` is empty, so
`isProxyGroup` always returns `false` and the filter has no effect.

## Solution

- Remove `isProxyGroup` filter from `speedGroupByName` in `stores/connections.ts` — keep it as a general-purpose speed map.
- Move the filter to the consumer in `pages/overview.vue`, applying `.filter(([name]) => !proxiesStore.isProxyGroup(name))` only where needed.
- Lazy-load proxy data in `overview.vue` via `onMounted` to ensure `isProxyGroup` works correctly even when overview is the first page visited.