### PR TITLE
fix: update ky v2 API - prefixUrl to prefix

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -105,7 +105,7 @@ export function useRequest() {
   }
 
   return ky.create({
-    prefixUrl: endpoint.url,
+    prefix: endpoint.url,
     headers,
     timeout: 5000,
   })
@@ -119,7 +119,7 @@ export function useGithubAPI() {
   }
 
   return ky.create({
-    prefixUrl: 'https://api.github.com',
+    prefix: 'https://api.github.com',
     headers,
   })
 }


### PR DESCRIPTION
### 问题描述
ky 库从 v1 升级到 v2.0.0 后，`prefixUrl` 选项被重命名为 `prefix`，导致所有 HTTP API 请求失败（WebSocket 连接不受影响）。

### 修复内容
将 `useRequest()` 和 `useGithubAPI()` 中的 `prefixUrl` 改为 `prefix`，以兼容 ky v2 API。

### 测试
- [x] 本地测试通过
