### PR TITLE
fix(api): update ky client configuration from prefixUrl to prefix

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -105,7 +105,7 @@ export function useRequest() {
   }
 
   return ky.create({
-    prefixUrl: endpoint.url,
+    prefix: endpoint.url,
     headers,
     timeout: 5000,
   })
@@ -119,7 +119,7 @@ export function useGithubAPI() {
   }
 
   return ky.create({
-    prefixUrl: 'https://api.github.com',
+    prefix: 'https://api.github.com',
     headers,
   })
 }


### PR DESCRIPTION
The ky library has deprecated the prefixUrl option in favor of prefix. This change updates the configuration to use the new option name while maintaining the same functionality.

以解决 5466f9578dcefe82ec8da194a0ffb75b37551f70 引起了：后端不可达 的报错