### PR TITLE
fix(charts): use browser local timezone instead of UTC in Highcharts

### DIFF
--- a/composables/useHighcharts.ts
+++ b/composables/useHighcharts.ts
@@ -11,9 +11,9 @@ export function loadHighcharts(): Promise<typeof Highcharts> {
   if (!highchartsPromise) {
     highchartsPromise = import('highcharts').then((module) => {
       const hc = module.default
-      // v12 removed useUTC; local timezone is the default. Apply once here
-      // instead of repeating it in every chart component.
-      hc.setOptions({ time: {} })
+      // v12 defaults to timezone: 'UTC'. Explicitly set to undefined so
+      // Intl.DateTimeFormat falls back to the browser's local timezone.
+      hc.setOptions({ time: { timezone: undefined } })
       return hc
     })
   }


### PR DESCRIPTION
Fixes #1973

Highcharts v12 defaults to timezone: 'UTC'. The previous setOptions({ time: {} }) passed an empty object which did not override the UTC default, causing chart axes and tooltips to display UTC timestamps — 8 hours behind for users in UTC+8 (e.g. China Standard Time).

Setting timezone: undefined makes Intl.DateTimeFormat fall back to the browser's local timezone, fixing all datetime axes and dateFormat calls across TrafficTrendChart, RealtimeLineChart, and GlobalTrafficIndicator.

