### PR TITLE
fix(connections): 恢复按目标 IP 搜索连接

### DIFF
--- a/components/connections/__tests__/globalFilter.spec.ts
+++ b/components/connections/__tests__/globalFilter.spec.ts
@@ -1,0 +1,95 @@
+import type { Connection } from '~/types'
+import { describe, expect, it } from 'vitest'
+import { connectionMatchesGlobalFilter } from '../globalFilter'
+
+function createConnection(overrides: {
+  metadata?: Partial<Connection['metadata']>
+  rule?: string
+  chains?: string[]
+}): Connection {
+  return {
+    id: 'conn-1',
+    download: 0,
+    upload: 0,
+    downloadSpeed: 0,
+    uploadSpeed: 0,
+    chains: overrides.chains ?? [],
+    rule: overrides.rule ?? '',
+    rulePayload: '',
+    start: '',
+    metadata: {
+      network: '',
+      type: '',
+      destinationIP: '',
+      destinationPort: '',
+      dnsMode: '',
+      host: '',
+      inboundIP: '',
+      inboundName: '',
+      inboundPort: '',
+      inboundUser: '',
+      process: '',
+      processPath: '',
+      remoteDestination: '',
+      sniffHost: '',
+      sourceIP: '',
+      sourcePort: '',
+      specialProxy: '',
+      specialRules: '',
+      uid: 0,
+      ...overrides.metadata,
+    },
+  }
+}
+
+describe('connectionMatchesGlobalFilter', () => {
+  it('matches by destination IP (#2013 regression)', () => {
+    const conn = createConnection({
+      metadata: { destinationIP: '192.168.1.100' },
+    })
+    expect(connectionMatchesGlobalFilter(conn, '192.168.1.100')).toBe(true)
+    expect(connectionMatchesGlobalFilter(conn, '192.168.1.')).toBe(true)
+  })
+
+  it('matches by remote destination', () => {
+    const conn = createConnection({
+      metadata: { remoteDestination: '203.0.113.7' },
+    })
+    expect(connectionMatchesGlobalFilter(conn, '203.0.113.7')).toBe(true)
+  })
+
+  it('still matches by host, source IP, process, rule and chains', () => {
+    const conn = createConnection({
+      metadata: {
+        host: 'example.com',
+        sourceIP: '10.0.0.5',
+        process: 'firefox',
+      },
+      rule: 'DOMAIN-SUFFIX',
+      chains: ['PROXY', 'Auto'],
+    })
+    expect(connectionMatchesGlobalFilter(conn, 'example.com')).toBe(true)
+    expect(connectionMatchesGlobalFilter(conn, '10.0.0.5')).toBe(true)
+    expect(connectionMatchesGlobalFilter(conn, 'firefox')).toBe(true)
+    expect(connectionMatchesGlobalFilter(conn, 'domain-suffix')).toBe(true)
+    expect(connectionMatchesGlobalFilter(conn, 'auto')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    const conn = createConnection({ metadata: { host: 'Example.COM' } })
+    expect(connectionMatchesGlobalFilter(conn, 'example.com')).toBe(true)
+  })
+
+  it('returns false when nothing matches', () => {
+    const conn = createConnection({
+      metadata: { destinationIP: '192.168.1.100', host: 'example.com' },
+    })
+    expect(connectionMatchesGlobalFilter(conn, '8.8.8.8')).toBe(false)
+  })
+
+  it('matches everything for an empty filter', () => {
+    const conn = createConnection({})
+    expect(connectionMatchesGlobalFilter(conn, '')).toBe(true)
+    expect(connectionMatchesGlobalFilter(conn, '   ')).toBe(true)
+  })
+})

--- a/components/connections/globalFilter.ts
+++ b/components/connections/globalFilter.ts
@@ -1,0 +1,27 @@
+import type { Connection } from '~/types'
+
+// Fields the connections search box matches against. This mirrors the columns
+// shown in the table so a search finds whatever the user can actually see.
+//
+// The destination IP / remote destination were dropped when the manual filter
+// replaced the old fuzzy column filter during the Nuxt migration, which broke
+// searching connections by IP address (#2013). They are restored here.
+export function connectionMatchesGlobalFilter(
+  conn: Connection,
+  filter: string,
+): boolean {
+  const needle = filter.trim().toLowerCase()
+  if (!needle) return true
+
+  const haystack = [
+    conn.metadata.host,
+    conn.metadata.destinationIP,
+    conn.metadata.remoteDestination,
+    conn.metadata.sourceIP,
+    conn.metadata.process,
+    conn.rule,
+    ...conn.chains,
+  ]
+
+  return haystack.some((value) => value?.toLowerCase().includes(needle))
+}

--- a/pages/connections.vue
+++ b/pages/connections.vue
@@ -5,6 +5,7 @@ import type { Connection } from '~/types'
 import { IconChevronRight, IconX } from '@tabler/icons-vue'
 import byteSize from 'byte-size'
 import { uniq } from 'lodash-es'
+import { connectionMatchesGlobalFilter } from '~/components/connections/globalFilter'
 import {
   closeAllConnectionsAPI,
   closeSingleConnectionAPI,
@@ -433,14 +434,8 @@ const filteredConnections = computed(() => {
 
   // Apply global filter
   if (globalFilter.value) {
-    const filter = globalFilter.value.toLowerCase()
-    connections = connections.filter(
-      (conn) =>
-        conn.metadata.host?.toLowerCase().includes(filter) ||
-        conn.metadata.process?.toLowerCase().includes(filter) ||
-        conn.metadata.sourceIP?.toLowerCase().includes(filter) ||
-        conn.rule?.toLowerCase().includes(filter) ||
-        conn.chains.some((c) => c.toLowerCase().includes(filter)),
+    connections = connections.filter((conn) =>
+      connectionMatchesGlobalFilter(conn, globalFilter.value),
     )
   }
 


### PR DESCRIPTION
## 问题

修复 #2013

旧版可以在连接页面搜索框里按 IP 地址搜索连接，Nuxt 迁移后搜不到了。

## 原因

迁移时把原本基于 TanStack Table 列的模糊搜索改成了手写过滤（`pages/connections.vue`），但漏掉了 **目标地址** 相关字段。新版只匹配 `host`、`process`、`sourceIP`、`rule`、`chains`，少了 `destinationIP` 和 `remoteDestination` —— 而这两个正是「目标」列展示的内容，所以按目标 IP 搜索就失效了。

## 改动

- 新增 `components/connections/globalFilter.ts`，把搜索匹配逻辑抽成可单测的纯函数 `connectionMatchesGlobalFilter`，并补回 `destinationIP` / `remoteDestination` 字段，使搜索覆盖范围与表格展示一致。
- `pages/connections.vue` 改为调用该函数。
- 新增 `components/connections/__tests__/globalFilter.spec.ts` 覆盖目标 IP、remote destination、host/sourceIP/process/rule/chains、大小写、空过滤等场景。

## 验证

- `pnpm test:unit`（connections）✅ 7 passed
- `pnpm exec eslint` ✅
- `pnpm exec vue-tsc --noEmit` ✅