### PR TITLE
fix: 修复 iOS 添加到主屏幕图标黑边

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -154,7 +154,15 @@ export default defineNuxtConfig({
       meta: [{ name: 'theme-color', content: '#000000' }],
       link: [
         { rel: 'icon', type: 'image/svg+xml', href: 'favicon.svg' },
-        { rel: 'apple-touch-icon', href: 'pwa-192x192.png' },
+        // iOS fills any transparent pixels of an apple-touch-icon with black,
+        // which gave the home-screen icon ugly black corners (#436). Point it
+        // at the opaque 180x180 PNG (the iOS-recommended size) instead of the
+        // 192x192 PWA icon, which has a transparent background.
+        {
+          rel: 'apple-touch-icon',
+          sizes: '180x180',
+          href: 'apple-touch-icon-180x180.png',
+        },
         // @vite-pwa/nuxt emits this file from the `pwa.manifest` config; we
         // link it here (instead of via <VitePwaManifest />) so it lands in the
         // static HTML shell. With ssr: false, component-injected head tags only


### PR DESCRIPTION
## 问题

修复 #436

在 iOS 上把面板「添加到主屏幕」后，图标四角出现黑边、不协调。

## 原因

iOS 会把 apple-touch-icon 的透明像素填充为黑色。当前 apple-touch-icon 指向 `pwa-192x192.png`，而这个 PNG 带有透明背景（含 `tRNS` 透明通道），于是透明区域在 iOS 上被填成了黑色。

## 改动

改为指向仓库中已有的 `public/apple-touch-icon-180x180.png`——它是 **不透明** 的（无透明通道），且 180×180 正是 iOS 推荐的 apple-touch-icon 尺寸，同时补上 `sizes` 属性。

无需新增资源文件，仅修改 `nuxt.config.ts` 的 `<link>` 指向。

## 验证

- `apple-touch-icon-180x180.png`：colortype=Palette，无 `tRNS` → 完全不透明 ✅
- `pwa-192x192.png`（原引用）：含 `tRNS` → 有透明背景（黑边根因）
- `pnpm exec eslint` ✅