### PR TITLE
docs: add CORS troubleshooting note for self-hosted setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,34 @@ pnpm generate
 pnpm preview
 ```
 
+## 🩺 Troubleshooting
+
+### "Unable to connect to backend" when self-hosting (CORS)
+
+If the dashboard loads but cannot connect to the Mihomo backend — even though
+the External Controller is reachable directly in your browser — the cause is
+usually **CORS**.
+
+When you host the dashboard on your own address (e.g. `http://192.168.1.2:8080`),
+the browser treats requests to the External Controller (e.g.
+`http://192.168.1.2:9090`) as cross-origin. Mihomo only answers cross-origin
+requests from origins listed in its `external-controller-cors` allow-list, so
+requests from your dashboard are rejected and the connection fails.
+
+Add your dashboard's origin to the allow-list in your Mihomo `config.yaml`:
+
+```yaml
+external-controller-cors:
+  allow-private-network: true
+  allow-origins:
+    - 'http://192.168.1.2:8080' # your dashboard's address
+    # or, for trusted local networks only:
+    # - '*'
+```
+
+> Tip: if you still cannot connect, open your browser's DevTools (F12) →
+> Console and look for CORS-related errors to confirm the cause.
+
 ## 🛠️ Development
 
 ```shell


### PR DESCRIPTION
## Problem

Closes #1958

Self-hosted users frequently hit **"Unable to connect to backend, please check the address and if the backend is running"** even when the Mihomo External Controller is directly reachable in the browser. The real cause is a **CORS** mismatch: the dashboard's origin (e.g. `http://nas-ip:8080`) is not in Mihomo's `external-controller-cors.allow-origins` list, so cross-origin requests to the controller (e.g. `http://nas-ip:9090`) are rejected. The generic error message gives no hint about this.

## Change

Add a **Troubleshooting** section to the README documenting:

- why the cross-origin request is blocked when self-hosting,
- how to add the dashboard origin to `external-controller-cors.allow-origins` in `config.yaml`,
- a tip to check DevTools → Console for CORS errors.

Docs-only change. Thanks to @jiezhengj for the detailed write-up in #1958.