### PR TITLE
fix(proxies): 让「自动切换到推荐节点」开关真正生效

### DIFF
--- a/pages/proxies.vue
+++ b/pages/proxies.vue
@@ -79,13 +79,26 @@ const getRecommendedNode = (proxyGroup: ProxyType) => {
 const testAllGroups = async () => {
   const groupNames = renderProxies.value.map((p) => p.name)
   await testMultipleGroups(groupNames)
+  autoSwitchAfterTest(renderProxies.value)
 }
 
-// Switch to recommended node in a group
+// Switch to recommended node in a group. No-op when there is no better node
+// than the one already selected — avoids needlessly pinning an automatic
+// (url-test/fallback) group to its current node.
 const switchToRecommended = (proxyGroup: ProxyType) => {
   const recommended = getRecommendedNode(proxyGroup)
-  if (recommended) {
+  if (recommended && recommended !== proxyGroup.now) {
     proxiesStore.selectProxyInGroup(proxyGroup, recommended)
+  }
+}
+
+// Honor the "auto switch to recommended" setting (#1971): once a latency test
+// has refreshed the performance data, move the tested group(s) to their
+// recommended node. Does nothing unless the user enabled the toggle.
+const autoSwitchAfterTest = (proxyGroups: ProxyType[]) => {
+  if (!nodeRecommendationStore.autoSwitchEnabled) return
+  for (const proxyGroup of proxyGroups) {
+    switchToRecommended(proxyGroup)
   }
 }
 
@@ -316,9 +329,12 @@ const ProxyGroupTitle = defineComponent({
                     proxiesStore.proxyGroupLatencyTestingMap[
                       props.proxyGroup.name
                     ],
-                  onClick: (e: MouseEvent) => {
+                  onClick: async (e: MouseEvent) => {
                     e.stopPropagation()
-                    proxiesStore.proxyGroupLatencyTest(props.proxyGroup.name)
+                    await proxiesStore.proxyGroupLatencyTest(
+                      props.proxyGroup.name,
+                    )
+                    autoSwitchAfterTest([props.proxyGroup])
                   },
                 },
                 {


### PR DESCRIPTION
## 问题

修复 #1971

设置页的「自动切换到推荐节点」（`autoSwitchToRecommended`）开关有 UI、也会持久化到 localStorage，但**全代码没有任何地方读取它**，所以打开后毫无效果——是个死开关（感谢 @ShaneLee-9 / @q657550306 在 #1971 的排查）。

## 改动

把开关接入两条测速路径，使其兑现描述「Automatically switch to the recommended node after testing」：

1. **「测试全部分组」**（`testAllGroups`）完成后，遍历各组切换到推荐节点；
2. **单个分组的延迟测试**按钮完成后，把该组切换到推荐节点。

推荐节点的计算复用现有的 `findRecommendedNode`（综合延迟 / 稳定性 / 成功率打分），与「魔法棒」手动切换按钮完全一致。

另外给 `switchToRecommended` 加了守卫：当推荐节点就是当前节点时不再调用选择接口——避免把 url-test/fallback 这类自动组**无意义地钉死**在当前节点上。

整个行为受开关控制，默认关闭，不影响未开启该选项的用户。

## 验证

- `pnpm test:unit` ✅ 201 passed（含 proxies / nodeRecommendation）
- `pnpm exec eslint` ✅
- `pnpm exec vue-tsc --noEmit` ✅