### PR TITLE
fix(proxies): 节点详情 tooltip 国旗使用 Twemoji

### DIFF
--- a/components/ProxyNodeTooltip.vue
+++ b/components/ProxyNodeTooltip.vue
@@ -22,6 +22,11 @@ defineEmits<{
   mouseLeave: []
 }>()
 
+// This tooltip teleports to <body>, escaping the layout root that carries the
+// font-twemoji / font-default class. Re-apply it here so node-name flag emoji
+// render with Twemoji to match the cards (#2017).
+const configStore = useConfigStore()
+
 const referenceEl = toRef(props, 'reference')
 const floating = ref<HTMLElement | null>(null)
 const floatingArrow = ref<HTMLElement | null>(null)
@@ -73,6 +78,7 @@ const arrowStyles = computed(() => {
       data-proxy-tooltip
       :style="floatingStyles"
       class="animate-pop-in z-50 w-max max-w-80 rounded-xl bg-primary p-3 text-primary-content shadow-[0_10px_40px_color-mix(in_oklch,var(--color-base-content)_30%,transparent)]"
+      :class="configStore.enableTwemoji ? 'font-twemoji' : 'font-default'"
       @mouseenter="$emit('mouseEnter')"
       @mouseleave="$emit('mouseLeave')"
     >


### PR DESCRIPTION
## 问题

修复 #2017

开启 Twemoji 后，节点卡片里的国旗 emoji 显示为 Twemoji，但**节点详情**（悬浮 tooltip）里的国旗却是系统原生 emoji。

## 原因

Twemoji 是通过在 layout 根元素上挂 `font-twemoji` 类（字体栈含 `Twemoji Mozilla`），让所有后代继承实现的。而节点详情 tooltip（`ProxyNodeTooltip.vue`）用 `<Teleport to="body">` 渲染到 `<body>` 下，处于 layout 根元素**之外**，继承不到 `font-twemoji`，于是回退到系统字体——国旗就不是 Twemoji 了。

## 改动

在 teleport 出去的 tooltip 根元素上，按 `configStore.enableTwemoji` 重新挂上同样的 `font-twemoji` / `font-default` 类，与卡片保持一致。

## 验证

- `pnpm exec eslint` ✅
- `pnpm exec vue-tsc --noEmit` ✅
- 视觉行为：tooltip 根元素现在与 layout 应用同一字体类（teleport 内容不再回退系统字体）