### PR TITLE
fix(versions): stop showing bogus backend update for sing-box

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -8,7 +8,7 @@ import type {
   RuleProvider,
 } from '~/types'
 import ky from 'ky'
-import { compareVersions } from '~/utils'
+import { compareVersions, isSingBoxVersion } from '~/utils'
 import { useMockData } from './useMockData'
 
 // Mock mode support
@@ -587,6 +587,11 @@ export async function frontendReleaseAPI(currentVersion: string) {
 }
 
 export async function backendReleaseAPI(currentVersion: string) {
+  // sing-box serves the clash API but isn't mihomo; checking its version
+  // against the mihomo release feed would always report a bogus "update
+  // available". Skip the check entirely for sing-box (#1870).
+  if (isSingBoxVersion(currentVersion)) return { isUpdateAvailable: false }
+
   const githubAPI = useGithubAPI()
   const repositoryURL = 'repos/MetaCubeX/mihomo'
   const match = BACKEND_VERSION_RE.exec(currentVersion)

--- a/pages/config.vue
+++ b/pages/config.vue
@@ -86,9 +86,7 @@ const {
 const updateConfigMutation = useUpdateConfigMutation()
 
 // Check if sing-box backend
-const isSingBox = computed(
-  () => backendVersion.value?.includes('sing-box') || false,
-)
+const isSingBox = computed(() => isSingBoxVersion(backendVersion.value))
 
 // TUN stack options
 const tunStacks = ['Mixed', 'gVisor', 'System', 'LWIP']

--- a/utils/__tests__/index.spec.ts
+++ b/utils/__tests__/index.spec.ts
@@ -9,6 +9,7 @@ import {
   formatProxyType,
   fuzzyFilter,
   getLatencyClassName,
+  isSingBoxVersion,
   sortProxiesByOrderingType,
   transformEndpointURL,
 } from '../index'
@@ -242,6 +243,25 @@ describe('utils/index', () => {
     it('handles different segment counts', () => {
       expect(compareVersions('1.243', '1.243.0')).toBe(0)
       expect(compareVersions('1.243.1', '1.243')).toBeGreaterThan(0)
+    })
+  })
+
+  describe('isSingBoxVersion', () => {
+    it('detects sing-box version strings (case-insensitive)', () => {
+      expect(isSingBoxVersion('sing-box 1.10.0')).toBe(true)
+      expect(isSingBoxVersion('SING-BOX-1.10.0')).toBe(true)
+    })
+
+    it('returns false for mihomo / clash version strings', () => {
+      expect(isSingBoxVersion('alpha-g1234567')).toBe(false)
+      expect(isSingBoxVersion('v1.19.9')).toBe(false)
+      expect(isSingBoxVersion('meta')).toBe(false)
+    })
+
+    it('handles empty / nullish input', () => {
+      expect(isSingBoxVersion('')).toBe(false)
+      expect(isSingBoxVersion(undefined)).toBe(false)
+      expect(isSingBoxVersion(null)).toBe(false)
     })
   })
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -94,6 +94,15 @@ export function compareVersions(v1: string, v2: string): number {
   return 0
 }
 
+// sing-box also serves the clash API, but reports its version as a string
+// containing "sing-box". Its releases live in a different repo with a
+// different cadence, so the dashboard cannot diff it against the mihomo
+// release feed — callers use this to skip the mihomo-based update check and
+// to hide mihomo-only settings (#1870).
+export function isSingBoxVersion(version: string | undefined | null): boolean {
+  return !!version && version.toLowerCase().includes('sing-box')
+}
+
 export function formatBytes(bytes: number) {
   return byteSize(bytes).toString()
 }


### PR DESCRIPTION
## Problem

Closes #1870

When the backend is **sing-box** (which also serves the clash API), the dashboard shows a backend "update available" prompt that never goes away.

## Cause

sing-box reports a version string containing `sing-box`, which does not match `BACKEND_VERSION_RE` (`/(alpha|beta|meta)-?(\w+)/`). `backendReleaseAPI` then falls through to the **stable-version** branch, fetches the latest `MetaCubeX/mihomo` release and compares it against the sing-box version — so it always reports an update available, pointing at the wrong project.

## Change

- Add an `isSingBoxVersion(version)` helper (`utils/index.ts`) and short-circuit `backendReleaseAPI` to return `{ isUpdateAvailable: false }` for sing-box — the dashboard can't meaningfully diff sing-box against the mihomo release feed.
- Reuse the same helper for the existing `isSingBox` computed in `config.vue` so backend detection is consistent and case-insensitive.

## Verification

- `pnpm test:unit` ✅ 204 passed (adds `isSingBoxVersion` cases)
- `pnpm exec eslint` ✅
- `pnpm exec vue-tsc --noEmit` ✅