### PR TITLE
fix(config): read unified delay from backend key

### DIFF
--- a/composables/useMockData.ts
+++ b/composables/useMockData.ts
@@ -17,6 +17,7 @@ export const mockConfig = {
   mode: 'rule',
   'log-level': 'info',
   'allow-lan': false,
+  'unified-delay': false,
   ipv6: false,
   tun: {
     enable: false,

--- a/pages/config.vue
+++ b/pages/config.vue
@@ -158,7 +158,8 @@ watch(
     if (config) {
       localConfig.allowLan = config['allow-lan'] || false
       localConfig.mode = config.mode || 'rule'
-      localConfig.unifiedDelay = config.UnifiedDelay || false
+      localConfig.unifiedDelay =
+        config['unified-delay'] ?? config.UnifiedDelay ?? false
       localConfig.interfaceName = config['interface-name'] || ''
       localConfig.tunEnable = config.tun?.enable || false
       localConfig.tunStack = config.tun?.stack || 'Mixed'

--- a/types/index.ts
+++ b/types/index.ts
@@ -157,7 +157,8 @@ export interface Config {
   'allow-lan': boolean
   'bind-address': string
   'inbound-tfo': boolean
-  UnifiedDelay: boolean
+  'unified-delay'?: boolean
+  UnifiedDelay?: boolean
   'log-level': string
   ipv6: boolean
   'interface-name': string


### PR DESCRIPTION
## Summary

The config page now reflects `unified-delay: true` from backend config responses instead of leaving the Unified Delay switch off. It still accepts legacy `UnifiedDelay` values when present, and the config type/mock data now include the kebab-case key used by the API.

## Tests

- pnpm typecheck
- pnpm test:unit
