### PR TITLE
feat(connections): resolve client & destination hostnames via reverse DNS

### DIFF
--- a/components/NetworkTopology.vue
+++ b/components/NetworkTopology.vue
@@ -17,6 +17,7 @@ const { t } = useI18n()
 
 const connectionsStore = useConnectionsStore()
 const configStore = useConfigStore()
+const reverseDns = useReverseDns()
 const svgRef = ref<SVGSVGElement | null>(null)
 const containerRef = ref<HTMLDivElement | null>(null)
 
@@ -80,6 +81,7 @@ interface TopologyNodeData {
   children?: TopologyNodeData[]
   _children?: TopologyNodeData[] // Store children when collapsed
   collapsed?: boolean
+  subtitle?: string // Raw value behind a friendly name (e.g. client IP)
 }
 
 // Build hierarchy data from active connections
@@ -183,7 +185,8 @@ const hierarchyData = computed<TopologyNodeData>(() => {
       ruleEntry.clients.set(clientIP, {
         data: {
           id: `client-${group}-${proxy}-${fullRule}-${clientIP}`,
-          name: clientIP,
+          name: reverseDns.label(clientIP),
+          subtitle: clientIP,
           type: 'client',
           connections: 0,
           traffic: 0,
@@ -673,12 +676,13 @@ function renderTree() {
     .text((d) => d.data.name)
 
   // Tooltips using title
-  nodes
-    .append('title')
-    .text(
-      (d) =>
-        `${d.data.name}\n${d.data.connections} connections\n${byteSize(d.data.traffic).toString()}`,
-    )
+  nodes.append('title').text((d) => {
+    const head =
+      d.data.subtitle && d.data.subtitle !== d.data.name
+        ? `${d.data.name} (${d.data.subtitle})`
+        : d.data.name
+    return `${head}\n${d.data.connections} connections\n${byteSize(d.data.traffic).toString()}`
+  })
 }
 
 // Toggle pause state

--- a/components/TrafficDetailsTable.vue
+++ b/components/TrafficDetailsTable.vue
@@ -19,6 +19,8 @@ const props = defineProps<{
   subStats: AggregatedData[]
   proxyStatsMap: Record<string, AggregatedData[]>
   selectedSubRow: string | null
+  labelFormatter?: (label: string) => string
+  labelTitle?: (label: string) => string
 }>()
 
 const emit = defineEmits<{
@@ -247,7 +249,18 @@ watch(
                       />
                       <IconChevronRight v-else :size="14" />
                     </div>
-                    <span class="truncate">{{ sub.label }}</span>
+                    <span
+                      class="truncate"
+                      :title="
+                        (sub.kind === 'sourceIP' && labelTitle?.(sub.label)) ||
+                        undefined
+                      "
+                      >{{
+                        sub.kind === 'sourceIP' && labelFormatter
+                          ? labelFormatter(sub.label)
+                          : sub.label
+                      }}</span
+                    >
                   </div>
 
                   <!-- Mobile-only compact stats -->
@@ -299,8 +312,16 @@ watch(
                   >
                     <span
                       class="mb-1 truncate border-b border-base-content/5 pb-1 font-mono text-[9px] font-bold text-secondary sm:text-[10px]"
-                      :title="item.label"
-                      >{{ item.label }}</span
+                      :title="
+                        (item.kind === 'sourceIP' &&
+                          labelTitle?.(item.label)) ||
+                        item.label
+                      "
+                      >{{
+                        item.kind === 'sourceIP' && labelFormatter
+                          ? labelFormatter(item.label)
+                          : item.label
+                      }}</span
                     >
                     <div
                       class="flex flex-col gap-1 text-[9px] font-bold sm:text-[10px]"

--- a/components/TrafficRankings.vue
+++ b/components/TrafficRankings.vue
@@ -1,20 +1,15 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
+import type { AggregatedData } from '~/composables/useDataUsage'
 import { formatBytes } from '~/utils'
-
-interface AggregatedData {
-  label: string
-  upload: number
-  download: number
-  total: number
-  count: number
-}
 
 defineProps<{
   title: string
   icon?: Component
   data: AggregatedData[]
   selectedRow: string | null
+  labelFormatter?: (label: string) => string
+  labelTitle?: (label: string) => string
 }>()
 
 const emit = defineEmits<{
@@ -49,7 +44,14 @@ const { t } = useI18n()
             :class="
               selectedRow === row.label ? 'text-primary' : 'text-base-content'
             "
-            >{{ row.label }}</span
+            :title="
+              (row.kind === 'sourceIP' && labelTitle?.(row.label)) || undefined
+            "
+            >{{
+              row.kind === 'sourceIP' && labelFormatter
+                ? labelFormatter(row.label)
+                : row.label
+            }}</span
           >
           <span
             class="shrink-0 text-xs font-black"

--- a/components/connections/ConnectionDetailsModal.vue
+++ b/components/connections/ConnectionDetailsModal.vue
@@ -12,9 +12,15 @@ const modalRef = ref<{ open: () => void; close: () => void }>()
 
 const { t } = useI18n()
 const geo = useGeoLookup()
+const configStore = useConfigStore()
+const reverseDns = useReverseDns()
 
 const destinationIP = computed(
   () => props.connection?.metadata.destinationIP || undefined,
+)
+
+const sourceIP = computed(
+  () => props.connection?.metadata.sourceIP || undefined,
 )
 
 // Resolve the destination IP's geo whenever the modal shows a new connection.
@@ -24,6 +30,12 @@ watchEffect(() => {
 })
 
 const destinationGeo = computed(() => geo.get(destinationIP.value))
+
+const sourceHostname = computed(() =>
+  configStore.resolveClientHostname
+    ? reverseDns.get(sourceIP.value)
+    : undefined,
+)
 
 defineExpose({
   open: () => modalRef.value?.open(),
@@ -130,7 +142,9 @@ defineExpose({
           <div class="min-w-0 font-mono break-all text-base-content">
             {{
               `${connection.metadata.sourceIP}:${connection.metadata.sourcePort}`
-            }}
+            }}<span v-if="sourceHostname" class="text-base-content/60">
+              ({{ sourceHostname }})</span
+            >
           </div>
           <div class="text-base-content/60">{{ t('destination') }}</div>
           <div class="min-w-0 font-mono break-all text-base-content">

--- a/composables/__tests__/useReverseDns.spec.ts
+++ b/composables/__tests__/useReverseDns.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { isResolvableIP, reverseName } from '../useReverseDns'
+
+describe('isResolvableIP', () => {
+  it('accepts private LAN IPv4 ranges', () => {
+    expect(isResolvableIP('10.0.0.1')).toBe(true)
+    expect(isResolvableIP('172.16.0.1')).toBe(true)
+    expect(isResolvableIP('172.31.255.254')).toBe(true)
+    expect(isResolvableIP('192.168.50.62')).toBe(true)
+  })
+
+  it('accepts public IPv4, including the 172.16/12 boundaries', () => {
+    expect(isResolvableIP('8.8.8.8')).toBe(true)
+    expect(isResolvableIP('1.1.1.1')).toBe(true)
+    expect(isResolvableIP('172.15.255.255')).toBe(true)
+    expect(isResolvableIP('172.32.0.0')).toBe(true)
+  })
+
+  it('rejects loopback, unspecified and link-local IPv4', () => {
+    expect(isResolvableIP('127.0.0.1')).toBe(false)
+    expect(isResolvableIP('0.0.0.0')).toBe(false)
+    expect(isResolvableIP('169.254.1.1')).toBe(false)
+  })
+
+  it('rejects empty and malformed IPv4', () => {
+    expect(isResolvableIP(undefined)).toBe(false)
+    expect(isResolvableIP('')).toBe(false)
+    expect(isResolvableIP('192.168.1')).toBe(false)
+    expect(isResolvableIP('192.168.1.999')).toBe(false)
+    expect(isResolvableIP('not-an-ip')).toBe(false)
+  })
+
+  it('accepts unique-local and global IPv6', () => {
+    expect(isResolvableIP('fd00::1234')).toBe(true)
+    expect(isResolvableIP('2001:db8::1')).toBe(true)
+  })
+
+  it('rejects loopback, unspecified and link-local IPv6 (incl. fe80::/10 and zone ids)', () => {
+    expect(isResolvableIP('::1')).toBe(false)
+    expect(isResolvableIP('::')).toBe(false)
+    expect(isResolvableIP('fe80::1')).toBe(false)
+    expect(isResolvableIP('feb0::1')).toBe(false)
+    expect(isResolvableIP('fe80::1%eth0')).toBe(false)
+  })
+})
+
+describe('reverseName', () => {
+  it('builds the in-addr.arpa name for IPv4', () => {
+    expect(reverseName('192.168.50.62')).toBe('62.50.168.192.in-addr.arpa')
+    expect(reverseName('8.8.8.8')).toBe('8.8.8.8.in-addr.arpa')
+  })
+
+  it('returns null for malformed IPv4', () => {
+    expect(reverseName('192.168.1')).toBeNull()
+    expect(reverseName('1.2.3.4.5')).toBeNull()
+    expect(reverseName('192.168.1.999')).toBeNull()
+    expect(reverseName('not-an-ip')).toBeNull()
+  })
+
+  it('builds the nibble-reversed ip6.arpa name for IPv6', () => {
+    expect(reverseName('2001:db8::1')).toBe(
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+    )
+    expect(reverseName('fd00::1234')).toBe(
+      '4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.f.ip6.arpa',
+    )
+  })
+
+  it('handles a fully-expanded IPv6 address (no "::")', () => {
+    expect(reverseName('2001:0db8:0000:0000:0000:0000:0000:0001')).toBe(
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+    )
+    expect(reverseName('2001:db8::1')).toBe(
+      reverseName('2001:0db8:0000:0000:0000:0000:0000:0001'),
+    )
+  })
+
+  it('normalises upper-case hex and strips an IPv6 zone id', () => {
+    expect(reverseName('2001:DB8::1')).toBe(reverseName('2001:db8::1'))
+    expect(reverseName('fe80::1%eth0')).toBe(reverseName('fe80::1'))
+  })
+
+  it('returns null for invalid IPv6 (multiple "::" or too many groups)', () => {
+    expect(reverseName('2001::db8::1')).toBeNull()
+    expect(reverseName('1:2:3:4:5:6:7::8:9')).toBeNull()
+  })
+})

--- a/composables/useDataUsage.ts
+++ b/composables/useDataUsage.ts
@@ -7,6 +7,9 @@ export interface AggregatedData {
   download: number
   total: number
   count: number
+  // What the label represents (e.g. 'sourceIP', 'host'), used by renderers for
+  // kind-specific display transforms.
+  kind?: DataUsageType
 }
 
 export const useDataUsage = () => {
@@ -47,6 +50,7 @@ export const useDataUsage = () => {
       } else {
         map.set(label, {
           label,
+          kind: type,
           upload: log.upload,
           download: log.download,
           total: log.upload + log.download,
@@ -91,6 +95,7 @@ export const useDataUsage = () => {
       } else {
         map.set(host, {
           label: host,
+          kind: 'host',
           upload: log.upload,
           download: log.download,
           total: log.upload + log.download,
@@ -137,6 +142,7 @@ export const useDataUsage = () => {
       } else {
         map.set(proxy, {
           label: proxy,
+          kind: 'outbound',
           upload: log.upload,
           download: log.download,
           total: log.upload + log.download,
@@ -168,6 +174,7 @@ export const useDataUsage = () => {
       } else {
         map.set(label, {
           label,
+          kind: 'sourceIP',
           upload: log.upload,
           download: log.download,
           total: log.upload + log.download,
@@ -202,6 +209,7 @@ export const useDataUsage = () => {
       } else {
         map.set(label, {
           label,
+          kind: 'sourceIP',
           upload: log.upload,
           download: log.download,
           total: log.upload + log.download,

--- a/composables/useReverseDns.ts
+++ b/composables/useReverseDns.ts
@@ -1,0 +1,248 @@
+import type { DNSQuery } from '~/types'
+
+// Reverse-DNS (PTR) resolver for IPs, via mihomo's dns/query endpoint so lookups
+// never leave the backend. Supports IPv4 and IPv6. Caches positives and
+// negatives with separate TTLs.
+
+interface HostnameEntry {
+  // null = resolved to "no hostname" (negative result).
+  name: string | null
+  ts: number
+}
+
+// Positives live ~45 min and persist across reloads. Negatives live ~10 min
+// and are NOT persisted, so a device that gets a name on its next DHCP lease
+// is re-checked after a reload instead of staying nameless.
+const POSITIVE_TTL = 45 * 60 * 1000
+const NEGATIVE_TTL = 10 * 60 * 1000
+const CACHE_KEY = 'reverseDnsCache'
+const CACHE_CAP = 200
+
+// Module-level singletons shared across all callers.
+const memoryCache = new Map<string, HostnameEntry>()
+const inflight = new Map<string, Promise<string | null>>()
+// Reactive registry of resolved names, keyed by IP. A lookup writes here once
+// resolved so every consumer re-renders.
+const hostnameState = reactive<Record<string, string>>({})
+
+// Writes into hostnameState are deferred to a microtask (deduped per IP) so they
+// never run synchronously during a render/computed.
+const pendingPromotions = new Set<string>()
+function promote(ip: string, name: string): void {
+  if (hostnameState[ip] === name || pendingPromotions.has(ip)) return
+  pendingPromotions.add(ip)
+  queueMicrotask(() => {
+    pendingPromotions.delete(ip)
+    if (hostnameState[ip] !== name) hostnameState[ip] = name
+  })
+}
+
+// Whether an IP is worth a PTR lookup at all. Skips empty, loopback,
+// unspecified and link-local addresses (no useful reverse record); everything
+// else — private LAN or public, IPv4 or IPv6 — is allowed.
+export function isResolvableIP(ip: string | undefined): boolean {
+  if (!ip) return false
+
+  if (ip.includes(':')) {
+    const lower = ip.split('%')[0]!.toLowerCase()
+    if (lower === '::' || lower === '::1') return false
+    if (/^fe[89ab]/.test(lower)) return false // fe80::/10 link-local
+    return true
+  }
+
+  const parts = ip.split('.')
+  if (parts.length !== 4) return false
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part) || Number(part) > 255) return false
+  }
+  const a = Number(parts[0])
+  const b = Number(parts[1])
+  if (a === 127 || a === 0) return false // loopback / unspecified
+  if (a === 169 && b === 254) return false // 169.254.0.0/16 link-local
+  return true
+}
+
+// 192.168.50.62 -> 62.50.168.192.in-addr.arpa
+function reverseNameV4(ip: string): string | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part) || Number(part) > 255) return null
+  }
+  return `${parts[3]}.${parts[2]}.${parts[1]}.${parts[0]}.in-addr.arpa`
+}
+
+// Expand to 32 nibbles, reverse, dot-join -> <nibbles>.ip6.arpa
+function reverseNameV6(ip: string): string | null {
+  const noZone = ip.split('%')[0]!
+  const halves = noZone.split('::')
+  if (halves.length > 2) return null
+
+  const head = halves[0] ? halves[0].split(':') : []
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : []
+
+  let groups: string[]
+  if (halves.length === 2) {
+    const missing = 8 - head.length - tail.length
+    if (missing < 0) return null
+    const pad: string[] = []
+    for (let i = 0; i < missing; i++) pad.push('0')
+    groups = [...head, ...pad, ...tail]
+  } else {
+    groups = head
+  }
+  if (groups.length !== 8) return null
+
+  let nibbles = ''
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/i.test(group)) return null
+    nibbles += group.padStart(4, '0').toLowerCase()
+  }
+  return `${nibbles.split('').reverse().join('.')}.ip6.arpa`
+}
+
+export function reverseName(ip: string): string | null {
+  return ip.includes(':') ? reverseNameV6(ip) : reverseNameV4(ip)
+}
+
+function isExpired(entry: HostnameEntry, now: number): boolean {
+  const ttl = entry.name === null ? NEGATIVE_TTL : POSITIVE_TTL
+  return now - entry.ts > ttl
+}
+
+type PersistedCache = Record<string, HostnameEntry>
+
+function readPersistedCache(): PersistedCache {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object'
+      ? (parsed as PersistedCache)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function writePersistedCache(cache: PersistedCache): void {
+  try {
+    const keys = Object.keys(cache)
+    if (keys.length > CACHE_CAP) {
+      const trimmed: PersistedCache = {}
+      for (const key of keys.slice(keys.length - CACHE_CAP)) {
+        const value = cache[key]
+        if (value) trimmed[key] = value
+      }
+      cache = trimmed
+    }
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+  } catch {
+    // Quota / serialization failures are non-fatal — resolution is best-effort.
+  }
+}
+
+// Only positives are persisted (negatives must be re-checked next session).
+function persistPositive(ip: string, entry: HostnameEntry): void {
+  const cache = readPersistedCache()
+  delete cache[ip]
+  cache[ip] = entry
+  writePersistedCache(cache)
+}
+
+let hydrated = false
+
+function hydrateMemoryFromPersisted(): void {
+  if (hydrated) return
+  hydrated = true
+  const now = Date.now()
+  for (const [ip, entry] of Object.entries(readPersistedCache())) {
+    if (
+      entry &&
+      typeof entry.name === 'string' &&
+      typeof entry.ts === 'number' &&
+      !isExpired(entry, now) &&
+      !memoryCache.has(ip)
+    ) {
+      memoryCache.set(ip, entry)
+    }
+  }
+}
+
+// Warm the in-memory cache from localStorage on module load.
+hydrateMemoryFromPersisted()
+
+export function useReverseDns() {
+  const configStore = useConfigStore()
+
+  async function fetchHostname(ip: string): Promise<string | null> {
+    const name = reverseName(ip)
+    if (!name) return null
+    try {
+      const request = useRequest()
+      const result = await request
+        .get('dns/query', { searchParams: { name, type: 'PTR' } })
+        .json<DNSQuery>()
+      // An answer record IS the hostname; its absence (NXDOMAIN or empty
+      // response) is a negative result. Strip the trailing dot mihomo appends
+      // (e.g. "iPhone." -> "iPhone").
+      const data = result.Answer?.[0]?.data
+      return data ? data.replace(/\.$/, '') : null
+    } catch {
+      return null
+    }
+  }
+
+  // Idempotent: kicks off (or reuses) a lookup. No-op when disabled or the IP
+  // isn't resolvable.
+  function lookup(ip: string | undefined): void {
+    if (!configStore.resolveClientHostname) return
+    if (!ip || !isResolvableIP(ip)) return
+
+    const now = Date.now()
+    const cached = memoryCache.get(ip)
+    if (cached) {
+      if (!isExpired(cached, now)) {
+        if (cached.name) promote(ip, cached.name)
+        return
+      }
+      // Expired: drop from both caches so a stale name can't linger.
+      memoryCache.delete(ip)
+      if (hostnameState[ip]) delete hostnameState[ip]
+    }
+
+    if (inflight.has(ip)) return
+
+    // Cache before freeing the inflight slot so a concurrent call can't race in.
+    const promise = fetchHostname(ip)
+    inflight.set(ip, promise)
+    promise
+      .then((name) => {
+        const entry: HostnameEntry = { name, ts: Date.now() }
+        memoryCache.set(ip, entry)
+        if (name) {
+          hostnameState[ip] = name
+          persistPositive(ip, entry)
+        }
+      })
+      .finally(() => inflight.delete(ip))
+  }
+
+  // Reactive getter — triggers a lookup and returns the resolved hostname, or
+  // undefined until resolved (or for skipped / negative IPs).
+  function get(ip: string | undefined): string | undefined {
+    if (!ip) return undefined
+    lookup(ip)
+    return hostnameState[ip]
+  }
+
+  // Display label: resolved hostname if available, otherwise the raw IP.
+  // Returns '' for an empty IP.
+  function label(ip: string | undefined): string {
+    if (!ip) return ''
+    if (!configStore.resolveClientHostname) return ip
+    return get(ip) || ip
+  }
+
+  return { lookup, get, label }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -160,6 +160,8 @@
   "flushFakeIP": "Flush Fake-IP",
   "flushDNSCache": "Flush DNS Cache",
   "tagClientSourceIPWithName": "Tag Client Source IP With Name",
+  "resolveClientHostname": "Resolve Hostnames (Reverse DNS)",
+  "resolveClientHostnameDesc": "Show device names for LAN clients and names for raw-IP destinations via reverse DNS. Requires mihomo's DNS to resolve the relevant reverse zones.",
   "tag": "Tag",
   "coreConfig": "Core Config",
   "xdConfig": "XD Config",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -160,6 +160,8 @@
   "flushFakeIP": "Очистить Fake-IP",
   "flushDNSCache": "Очистить кэш DNS",
   "tagClientSourceIPWithName": "Пометить IP клиента именем",
+  "resolveClientHostname": "Определять имена по reverse DNS",
+  "resolveClientHostnameDesc": "Показывать имена устройств LAN-клиентов и имена для destination без host через обратный DNS. Требует, чтобы DNS mihomo резолвил соответствующие обратные зоны.",
   "tag": "Метка",
   "coreConfig": "Конфиг ядра",
   "xdConfig": "Конфиг XD",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -160,6 +160,8 @@
   "flushFakeIP": "清空 Fake-IP",
   "flushDNSCache": "清空 DNS 缓存",
   "tagClientSourceIPWithName": "为客户端源 IP 地址添加名称标记",
+  "resolveClientHostname": "通过反向 DNS 解析主机名",
+  "resolveClientHostnameDesc": "通过反向 DNS 为局域网客户端和无 host 的目标 IP 显示名称。需要 mihomo 的 DNS 能解析相应的反向区域。",
   "tag": "标记",
   "coreConfig": "核心配置",
   "xdConfig": "XD 配置",

--- a/pages/config.vue
+++ b/pages/config.vue
@@ -647,6 +647,22 @@ const activeSection = ref<'core' | 'xd' | 'tools'>('core')
                 />
               </div>
 
+              <div
+                class="flex items-center justify-between gap-4 rounded-lg px-2 py-1.5 transition-colors hover:bg-base-content/5"
+              >
+                <div class="flex flex-col gap-0.5">
+                  <span class="text-sm">{{ t('resolveClientHostname') }}</span>
+                  <span class="text-xs opacity-50">{{
+                    t('resolveClientHostnameDesc')
+                  }}</span>
+                </div>
+                <input
+                  v-model="configStore.resolveClientHostname"
+                  type="checkbox"
+                  class="toggle toggle-primary"
+                />
+              </div>
+
               <!-- Mobile Bottom Nav Toggle - only visible on mobile -->
               <div
                 class="flex items-center justify-between gap-4 rounded-lg px-2 py-1.5 transition-colors hover:bg-base-content/5 lg:hidden"

--- a/pages/connections.vue
+++ b/pages/connections.vue
@@ -5,6 +5,7 @@ import type { Connection } from '~/types'
 import { IconChevronRight, IconX } from '@tabler/icons-vue'
 import byteSize from 'byte-size'
 import { uniq } from 'lodash-es'
+import { h } from 'vue'
 import { connectionMatchesGlobalFilter } from '~/components/connections/globalFilter'
 import {
   closeAllConnectionsAPI,
@@ -19,6 +20,7 @@ const { t, locale } = useI18n()
 useHead({ title: computed(() => t('connections')) })
 const connectionsStore = useConnectionsStore()
 const configStore = useConfigStore()
+const reverseDns = useReverseDns()
 
 // Modals
 const settingsModal = ref<{ open: () => void; close: () => void }>()
@@ -73,10 +75,23 @@ function getRule(conn: Connection) {
   return !conn.rulePayload ? conn.rule : `${conn.rule} : ${conn.rulePayload}`
 }
 
+// Group/sort key (manual tag or raw IP).
 function getSourceIP(conn: Connection) {
   const src = conn.metadata.sourceIP || t('inner')
   const tag = configStore.clientSourceIPTags.find((tag) => tag.sourceIP === src)
   return tag?.tagName || src
+}
+
+// Display label: manual tag -> resolved hostname -> raw IP.
+function getSourceLabel(conn: Connection) {
+  const src = conn.metadata.sourceIP || t('inner')
+  const tag = configStore.clientSourceIPTags.find((tag) => tag.sourceIP === src)
+  if (tag?.tagName) return tag.tagName
+  if (configStore.resolveClientHostname) {
+    const name = reverseDns.get(conn.metadata.sourceIP)
+    if (name) return name
+  }
+  return src
 }
 
 function getDestination(conn: Connection) {
@@ -85,6 +100,29 @@ function getDestination(conn: Connection) {
     conn.metadata.destinationIP ||
     conn.metadata.host
   )
+}
+
+// Bare-IP destination with no host — the only case worth a reverse lookup.
+function destinationNeedsReverseDns(conn: Connection) {
+  return !conn.metadata.host && !!conn.metadata.destinationIP
+}
+
+function getHostLabel(conn: Connection) {
+  if (destinationNeedsReverseDns(conn)) {
+    const ip = conn.metadata.destinationIP
+    const name = reverseDns.label(ip)
+    if (name && name !== ip) return `${name}:${conn.metadata.destinationPort}`
+  }
+  return getHost(conn)
+}
+
+function getDestinationLabel(conn: Connection) {
+  if (destinationNeedsReverseDns(conn)) {
+    const ip = conn.metadata.destinationIP
+    const name = reverseDns.label(ip)
+    if (name && name !== ip) return name
+  }
+  return getDestination(conn)
 }
 
 function getInboundUser(conn: Connection) {
@@ -148,7 +186,11 @@ const allColumns: ConnectionColumn[] = [
     groupable: true,
     sortable: true,
     sortId: 'Host',
-    render: (conn: Connection) => getHost(conn),
+    render: (conn: Connection) => {
+      const label = getHostLabel(conn)
+      const raw = getHost(conn)
+      return h('span', { title: label !== raw ? raw : undefined }, label)
+    },
     groupValue: (conn: Connection) => getHost(conn),
   },
   {
@@ -235,7 +277,11 @@ const allColumns: ConnectionColumn[] = [
     groupable: true,
     sortable: true,
     sortId: 'SourceIP',
-    render: (conn: Connection) => getSourceIP(conn),
+    render: (conn: Connection) => {
+      const label = getSourceLabel(conn)
+      const raw = conn.metadata.sourceIP || t('inner')
+      return h('span', { title: label !== raw ? raw : undefined }, label)
+    },
     groupValue: (conn: Connection) => getSourceIP(conn),
   },
   {
@@ -250,7 +296,11 @@ const allColumns: ConnectionColumn[] = [
     key: 'destination',
     groupable: true,
     sortable: false,
-    render: (conn: Connection) => getDestination(conn),
+    render: (conn: Connection) => {
+      const label = getDestinationLabel(conn)
+      const raw = getDestination(conn)
+      return h('span', { title: label !== raw ? raw : undefined }, label)
+    },
     groupValue: (conn: Connection) => getDestination(conn),
   },
   {
@@ -270,10 +320,11 @@ const allColumns: ConnectionColumn[] = [
     sortable: true,
     sortId: 'Host',
     render: (conn: Connection) => {
-      const primary = getHost(conn)
+      const primary = getHostLabel(conn)
       const proc = getProcess(conn)
       const aux = proc !== '-' ? proc : ''
-      return renderTwoLineCell(primary, aux)
+      const raw = getHost(conn)
+      return renderTwoLineCell(primary, aux, primary !== raw ? raw : undefined)
     },
     renderText: (conn: Connection) => {
       const proc = getProcess(conn)
@@ -324,10 +375,17 @@ const allColumns: ConnectionColumn[] = [
     sortable: true,
     sortId: 'SourceIP',
     render: (conn: Connection) => {
-      const primary = `${getSourceIP(conn)}:${conn.metadata.sourcePort}`
-      const dest = getDestination(conn)
+      const primary = `${getSourceLabel(conn)}:${conn.metadata.sourcePort}`
+      const dest = getDestinationLabel(conn)
       const aux = dest ? `→ ${dest}` : ''
-      return renderTwoLineCell(primary, aux)
+      const rawDest = getDestination(conn)
+      const rawSource = `${conn.metadata.sourceIP || t('inner')}:${conn.metadata.sourcePort}`
+      return renderTwoLineCell(
+        primary,
+        aux,
+        primary !== rawSource ? rawSource : undefined,
+        dest && dest !== rawDest ? `→ ${rawDest}` : undefined,
+      )
     },
     renderText: (conn: Connection) => {
       const dest = getDestination(conn)

--- a/pages/traffic.vue
+++ b/pages/traffic.vue
@@ -20,6 +20,7 @@ import { formatBytes, formatDuration } from '~/utils'
 
 const { t } = useI18n()
 const connectionsStore = useConnectionsStore()
+const reverseDns = useReverseDns()
 const {
   getAggregatedData,
   getSubStatsByHost,
@@ -28,6 +29,12 @@ const {
   getDevicesByHost,
   getDevicesByProxyAndHost,
 } = useDataUsage()
+
+const formatClientLabel = (ip: string) => reverseDns.label(ip)
+const clientLabelTitle = (ip: string) => {
+  const name = reverseDns.label(ip)
+  return name !== ip ? ip : ''
+}
 
 useHead({ title: computed(() => t('dataUsage')) })
 type SortField = 'label' | 'upload' | 'download' | 'total' | 'count'
@@ -473,6 +480,8 @@ const currentViewLabel = computed(
               :icon="currentViewOption?.icon"
               :data="sortedDataUsageEntries"
               :selected-row="selectedRow"
+              :label-formatter="formatClientLabel"
+              :label-title="clientLabelTitle"
               @select="handleRowClick"
             />
           </div>
@@ -498,6 +507,8 @@ const currentViewLabel = computed(
             :sub-stats="subStatsMap[selectedRow] || []"
             :proxy-stats-map="proxyStatsMap"
             :selected-sub-row="selectedSubRow"
+            :label-formatter="formatClientLabel"
+            :label-title="clientLabelTitle"
             @sub-row-click="handleSubRowClick"
           />
         </div>

--- a/stores/config.ts
+++ b/stores/config.ts
@@ -204,6 +204,10 @@ export const useConfigStore = defineStore('config', () => {
     'ipwho.is',
   )
 
+  // Resolve IPs to hostnames via reverse DNS (PTR) through mihomo's dns/query
+  // endpoint. Off by default; needs mihomo's DNS configured for reverse zones.
+  const resolveClientHostname = useLocalStorage('resolveClientHostname', false)
+
   // Appearance: custom background. 'custom' = user-uploaded image (IndexedDB),
   // 'url' = remote image URL (e.g. a Bing daily-wallpaper endpoint).
   const backgroundImageType = useLocalStorage<'none' | 'custom' | 'url'>(
@@ -366,6 +370,8 @@ export const useConfigStore = defineStore('config', () => {
     // Connections GeoIP
     showConnectionGeoIP,
     connectionGeoIPProvider,
+    // Reverse-DNS hostname resolution
+    resolveClientHostname,
     // Appearance
     backgroundImageType,
     backgroundImageUrl,

--- a/utils/connectionCells.ts
+++ b/utils/connectionCells.ts
@@ -7,14 +7,26 @@ import { h } from 'vue'
  * primary div is rendered — combined with the parent `<td>`'s
  * `vertical-align: middle`, the primary line is vertically centered
  * in the cell instead of being pinned to the top by an empty placeholder.
+ *
+ * `primaryTitle` / `auxTitle` set hover tooltips on the respective lines.
  */
 export function renderTwoLineCell(
   primary: string,
   aux: string | null | undefined,
+  primaryTitle?: string | null,
+  auxTitle?: string | null,
 ): VNode {
-  const children: VNode[] = [h('div', { class: 'conn-primary' }, primary)]
+  const children: VNode[] = [
+    h(
+      'div',
+      { class: 'conn-primary', title: primaryTitle || undefined },
+      primary,
+    ),
+  ]
   if (aux) {
-    children.push(h('div', { class: 'conn-aux' }, aux))
+    children.push(
+      h('div', { class: 'conn-aux', title: auxTitle || undefined }, aux),
+    )
   }
   return h('div', { class: 'conn-cell-stack' }, children)
 }


### PR DESCRIPTION
## What & why

Connections, Data Usage and the network topology show clients (and some destinations) only by raw IP. Most LAN devices already have a friendly name in DHCP/DNS, reachable via reverse DNS (PTR). This resolves those IPs to hostnames through mihomo's existing `dns/query` endpoint — nothing leaves the mihomo backend.

Off by default.

## What changes

- **New `useReverseDns` composable** — generic PTR resolver (IPv4 + IPv6) over the existing `dns/query` endpoint. Mirrors `useGeoLookup` (reactive registry + cache + in-flight dedup), with memory + localStorage caching and split positive/negative TTLs (DHCP leases migrate). Demand-driven: `get()`/`label()` trigger the lookup themselves; reactive promotions are deferred to a microtask so reads stay render-safe.
- **Surfaces:** connections table (source IP, and host-less destination IPs), Data Usage (rankings / details / proxy-view device breakdown), network topology (client nodes).
- **Display decoupled from keys:** grouping, aggregation, node identity, sort and filter stay on the raw IP; only the rendered text changes. The raw IP stays available via tooltip.
- **Precedence:** connections — manual tag → hostname → IP; other views — hostname → IP.
- `AggregatedData.kind` tags which Data Usage labels are IPs, so renderers don't infer it from the active view.
- **Global toggle** `resolveClientHostname` in Config (off by default); i18n for en/zh/ru.

## Prerequisite

Resolution relies on mihomo being able to resolve the LAN reverse zone. If your DHCP/DNS server (dnsmasq / AdGuard Home / Pi-hole) holds the client names, route that reverse zone to it:

```yaml
dns:
  nameserver-policy:
    # example for a 192.168.1.0/24 LAN -> your local resolver
    '+.1.168.192.in-addr.arpa': '192.168.1.1'
```

Use the narrow subnet reverse zone (not `+.in-addr.arpa`) so public reverse lookups keep using your normal upstream. For IPv6 clients, route the matching `ip6.arpa` zone the same way. The in-app toggle hint points users at this requirement.

## Notes

- No breaking changes; feature is opt-in and degrades gracefully (no record → shows the IP).
- Search and sort operate on the raw IP, not the resolved name (display-only change).
- With transparent TUN proxying, ensure the connection's `sourceIP` is the real client (no SNAT before mihomo), otherwise the resolved name is the gateway's.

## Testing

- Unit tests for the reverse-DNS helpers (`reverseName` IPv4/IPv6, `isResolvableIP`).
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:unit` — 244 passed ✅
- `pnpm test:e2e` — 13 passed ✅
- `pnpm build` / `pnpm build:mock` ✅

## Screenshots
<details>
  <summary><b>Network Topology</b></summary>
<img width="950" height="791" alt="SCR-20260617-rlcf" src="https://github.com/user-attachments/assets/03adf317-7a0b-4953-a05b-83c790db86e0" />
  </details>

<details>
  <summary><b>Connections</b></summary>
<img width="575" height="774" alt="SCR-20260617-rlef" src="https://github.com/user-attachments/assets/0d0ce478-f0f0-4d60-a2ee-91492078724d" />
  </details>

<details>
  <summary><b>Data Usage</b></summary>
<img width="484" height="496" alt="изображение" src="https://github.com/user-attachments/assets/f86a4b9f-f63f-4087-9a33-ca1cba967d37" />
  </details>