### PR TITLE
fix(ui): spin only the refresh icon and unify overview refresh buttons

### DIFF
--- a/packages/ui/components/IPInfoCard.vue
+++ b/packages/ui/components/IPInfoCard.vue
@@ -64,11 +64,13 @@ function handleProviderChange(event: Event) {
         </select>
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-base-content/10 bg-transparent text-base-content/60 transition-all duration-200 hover:bg-base-300 hover:text-base-content disabled:cursor-not-allowed disabled:opacity-50"
-          :class="{ 'animate-spin': isLoading }"
           :disabled="isLoading"
           @click="fetchIP()"
         >
-          <IconRefresh :size="16" />
+          <IconRefresh
+            :size="16"
+            :class="{ 'animate-spin [animation-direction:reverse]': isLoading }"
+          />
         </button>
       </div>
     </div>

--- a/packages/ui/components/LatencyCard.vue
+++ b/packages/ui/components/LatencyCard.vue
@@ -56,12 +56,16 @@ function getLatencyBarClass(latency: number | null | undefined) {
           {{ t('average') }}: {{ averageLatency }}ms
         </span>
         <button
-          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border-none bg-transparent text-base-content/60 transition-all duration-200 hover:bg-base-content/10 hover:text-base-content disabled:cursor-not-allowed disabled:opacity-50"
-          :class="{ 'animate-spin': isTestingAll }"
+          class="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-base-content/10 bg-transparent text-base-content/60 transition-all duration-200 hover:bg-base-300 hover:text-base-content disabled:cursor-not-allowed disabled:opacity-50"
           :disabled="isTestingAll"
           @click="testAllLatencies"
         >
-          <IconRefresh class="h-4 w-4" />
+          <IconRefresh
+            :size="16"
+            :class="{
+              'animate-spin [animation-direction:reverse]': isTestingAll,
+            }"
+          />
         </button>
       </div>
     </div>


### PR DESCRIPTION
Closes #2089

Overview 页两个刷新按钮的三处问题：

1. **只转图标，边框不动** — `animate-spin` 从 `<button>` 移到内部 `<IconRefresh>`，圆角矩形边框保持不动。
2. **方向与箭头一致** — `IconRefresh` 箭头是逆时针，加 `[animation-direction:reverse]` 让动画也逆时针旋转。
3. **统一两个按钮样式** — Network Latency 的圆形无边框按钮改成与 Current IP 一致的圆角矩形带边框。