### PR TITLE
feat(docker): publish the standalone metacubexd panel image again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,8 @@ jobs:
           files: compressed-dist.tgz
           tag_name: ${{ needs.release-please.outputs.tag_name }}
 
-  # NOTE: the legacy static-panel image (ghcr.io/metacubex/metacubexd) built from
-  # a repo-root Dockerfile was dropped in the monorepo migration (the Dockerfile
-  # no longer exists). The hosted gh-pages panel + the all-in-one server image
-  # below supersede it.
+  # All-in-one image (ghcr.io/metacubex/metacubexd-server): bundles the mihomo
+  # kernel + Nitro server + dashboard in one container.
   release-server-image:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
@@ -133,6 +131,56 @@ jobs:
           tags: |
             ghcr.io/metacubex/metacubexd-server:latest
             ghcr.io/metacubex/metacubexd-server:${{ needs.release-please.outputs.tag_name }}
+
+  # Standalone panel image (ghcr.io/metacubex/metacubexd): ships only the
+  # dashboard over HTTP, so it can be self-hosted to manage one or more mihomo
+  # backends without the hosted gh-pages panel's HTTPS mixed-content block.
+  release-panel-image:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-docker-action@v5
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - uses: docker/setup-buildx-action@v4
+        id: buildx
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: packages/ui/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=panel
+          cache-to: type=gha,mode=max,scope=panel
+          tags: |
+            ghcr.io/metacubex/metacubexd:latest
+            ghcr.io/metacubex/metacubexd:${{ needs.release-please.outputs.tag_name }}
 
   release-desktop:
     needs: release-please

--- a/README.md
+++ b/README.md
@@ -285,35 +285,29 @@ With `network_mode: host` the `ports:` mapping is ignored — the container
 binds `8080`/`9090`/`7890` directly on the host. Enable a `tun:` block in your
 profile's mihomo config for the tunnel to come up.
 
-### Migrating from the legacy `metacubexd` image
+### Standalone panel image (Docker)
 
-The old **`ghcr.io/metacubex/metacubexd`** image was a **static dashboard only**
-— it served the UI and you pointed it at a mihomo you ran yourself (often a
-separate `mihomo` container). The monorepo migration **froze that image** (its
-repo-root `Dockerfile` is gone), which is why pulls stopped updating. Nothing is
-broken — the dashboard moved to two supported forms, so pick the one that
-matches your old setup:
+**`ghcr.io/metacubex/metacubexd`** is a **dashboard-only** image — it serves the
+UI over plain HTTP on port `80` and you point it at a mihomo you run yourself
+(often a separate `mihomo` container). One panel container can drive several
+mihomo backends, and because it speaks HTTP there is no HTTPS mixed-content block
+like the hosted gh-pages page hits when you aim it at a local backend.
 
-- **You want to keep running your own mihomo** (you had a separate `mihomo`
-  container or a host mihomo). You don't need a dashboard container at all — open
-  the [hosted panel](#1-hosted-panel-point-at-your-own-mihomo) and enter your
-  mihomo's `{url, secret}`, or self-host the static assets via `external-ui`.
-  Add your dashboard origin to `external-controller-cors` (see
-  [CORS](#unable-to-connect-to-backend-when-self-hosting-cors)).
+```shell
+docker run -d --name metacubexd -p 80:80 ghcr.io/metacubex/metacubexd:latest
+```
 
-- **You want one container that runs everything.** Switch to
-  [`metacubexd-server`](#3-all-in-one-server-docker). It **bundles its own
-  mihomo**, so the old `# Optional: mihomo instance` service is no longer needed
-  — **delete it**. Move your `config.yaml` in as a profile (paste it into the
-  in-app config editor, or drop it under the `/data` volume) instead of mounting
-  it at mihomo's old path.
+> This image was briefly frozen during the monorepo migration; it is published
+> again, so `docker pull ghcr.io/metacubex/metacubexd:latest` resumes updating.
+> Add your dashboard origin to `external-controller-cors` (see
+> [CORS](#unable-to-connect-to-backend-when-self-hosting-cors)).
 
-Two gotchas when porting an old `compose.yaml`:
-
-- **Port.** The legacy image listened on `80`; the server's dashboard is `8080`.
-  Map `'80:8080'` if you want to keep hitting it on port 80.
-- **Image name.** `ghcr.io/metacubex/metacubexd` →
-  `ghcr.io/metacubex/metacubexd-server:latest`.
+Prefer **one container that runs everything**? Use
+[`metacubexd-server`](#3-all-in-one-server-docker) instead — it **bundles its own
+mihomo**. When porting an old standalone `compose.yaml` to it, the old
+`# Optional: mihomo instance` service is no longer needed (**delete it**), the
+dashboard moves from port `80` to `8080` (map `'80:8080'` to keep port 80), and
+the image name becomes `ghcr.io/metacubex/metacubexd-server:latest`.
 
 ### Profiles & Config Editor (desktop / server)
 

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -1,29 +1,25 @@
-FROM --platform=$BUILDPLATFORM docker.io/node:alpine AS builder
+# syntax=docker/dockerfile:1
+# Standalone metacubexd panel (Nuxt node-server, ships only the dashboard).
+# Build context MUST be the repo root: docker buildx build -f packages/ui/Dockerfile .
 
-USER root
-ENV PNPM_HOME=/pnpm
-ENV PATH=$PNPM_HOME:$PATH
-ENV HUSKY=0
-WORKDIR /build
-
-COPY . .
-
-RUN npm install --force -g corepack
+# ---- Stage 1: build the Nuxt node-server output (on the builder's native arch) ----
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH HUSKY=0
+WORKDIR /repo
 RUN corepack enable
-RUN corepack install
-RUN pnpm install
-RUN pnpm build
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json tsconfig.base.json ./
+COPY packages/ packages/
+COPY apps/ apps/
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @metacubexd/ui build
+# -> /repo/packages/ui/.output (Nitro node-server preset, serves the CSR panel)
 
-FROM docker.io/node:alpine
-
-ENV PORT=80
+# ---- Stage 2: slim runtime ----
+FROM node:22-alpine
+ENV PORT=80 NODE_ENV=production
 EXPOSE 80
-
 WORKDIR /app
-
-# Copy the entire Nuxt server output
-COPY --from=builder /build/.output ./.output
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY --from=builder /repo/packages/ui/.output ./.output
+COPY packages/ui/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
-
 CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Closes #2088

### 背景
monorepo 迁移时删掉了 dashboard-only 的 `ghcr.io/metacubex/metacubexd` 镜像，现在只剩托管的 gh-pages 页和 all-in-one 的 `metacubexd-server`。结果：

- 托管页是 HTTPS，浏览器拦截它连本地 HTTP 的 mihomo 后端（混合内容，JS 层无法绕过）。
- all-in-one 镜像把内核和面板捆在一个容器里，不适合"一个轻量面板管多个 mihomo 内核"的用法。

### 改动
- **`packages/ui/Dockerfile`** — 重写为 workspace 感知的多阶段构建。原版用 `catalog:` 依赖却在非 workspace 上下文 `pnpm install`，且根 `pnpm build` 产不出 `.output`，**实际无法构建**。新版照 `apps/server/Dockerfile` 的成熟写法，产出 Nitro node-server，端口 80，保留 `DEFAULT_BACKEND_URL` 运行时配置——与旧镜像名称/端口/行为一致，老用户无缝切回。
- **`.github/workflows/release.yml`** — 新增 `release-panel-image` job，多架构（amd64/arm64）构建并推送 `ghcr.io/metacubex/metacubexd:latest` + 版本 tag；用独立 `scope=panel` GHA 缓存避免和 server job 撞；修正过时注释。
- **`README.md`** — 把"legacy image 已冻结/Dockerfile 已删"那节改写为"恢复发布的独立面板镜像"，含 `docker run` 示例和它解决的混合内容/多后端场景。

### 本地验证
- `docker buildx build -f packages/ui/Dockerfile .` 成功（产出 `.output/server/index.mjs`，镜像 ~172MB）。
- 容器 `HTTP 200` serve 出 `<title>MetaCubeXD</title>` 面板，监听 80。
- `-e DEFAULT_BACKEND_URL=...` 正确注入到 payload 的 `defaultBackendURL`。