### PR TITLE
fix(desktop): handle linux helper not found

### DIFF
--- a/apps/desktop/src/main/helper/installer.ts
+++ b/apps/desktop/src/main/helper/installer.ts
@@ -256,8 +256,20 @@ export function createHelperInstaller(
   }
 
   async function linuxIsInstalled(): Promise<boolean> {
-    const { stdout } = await exec(`systemctl is-enabled ${serviceName}`)
-    return /\benabled\b/.test(stdout)
+    try {
+      const { stdout } = await exec(`systemctl is-enabled ${serviceName}`)
+      return /\benabled\b/.test(stdout)
+    } catch (err) {
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'code' in err &&
+        err.code === 4 // not-found
+      ) {
+        return false
+      }
+      throw err
+    }
   }
 
   // ---- Windows (sc + UAC runas) ----


### PR DESCRIPTION
Problem: When turning on TUN mode without privilege helper installed, application throws internal error due to `systemctl is-enabled metacubexd-helper` exiting with error.

Fix: Catch `systemctl is-enabled` error code 4, which indicates that a service is not found.

Tested on x86_64 linux manually by turning on TUN mode. Helper subsequently installed correctly.